### PR TITLE
Bot再起動時にアクティブスレッドのWorkerを復旧する処理を追加

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -73,6 +73,11 @@ const commands = [
 client.once(Events.ClientReady, async (readyClient) => {
   console.log(`ログイン完了: ${readyClient.user.tag}`);
 
+  // アクティブなスレッドを復旧
+  console.log("アクティブなスレッドを復旧しています...");
+  await admin.restoreActiveThreads();
+  console.log("スレッドの復旧が完了しました。");
+
   // スラッシュコマンドを登録
   const rest = new REST({ version: "10" }).setToken(env.DISCORD_TOKEN);
 


### PR DESCRIPTION
## Summary
- Bot再起動時に前回のアクティブなスレッドのWorkerインスタンスを復旧する処理を追加
- これにより再起動後も前回のスレッドを正常に終了できるようになる

## 問題の詳細
再起動後に前回起動時に開始したスレッドを終了しようとすると「Worker見つからず、終了処理スキップ」というログが出る問題がありました。

### 原因
- スレッド情報自体は`threads/`ディレクトリに永続化されていた
- しかし、Bot起動時にWorkerインスタンスがメモリ上に復旧されていなかった
- `main.ts`で`admin.restoreActiveThreads()`が呼ばれていなかった

### 修正内容
- Bot起動時（`ClientReady`イベント）に`admin.restoreActiveThreads()`を呼び出すように修正
- これにより以下が実行される：
  1. アクティブなスレッド情報を読み込む
  2. 各スレッドに対してWorkerインスタンスを作成
  3. リポジトリ情報とdevcontainer設定を復旧
  4. Workerを管理Mapに追加

## Test plan
- [ ] Botを起動してスレッドを作成
- [ ] Botを再起動
- [ ] 再起動後に前回のスレッドでメッセージを送信できることを確認
- [ ] 再起動後に前回のスレッドを終了できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)