### PR TITLE
feat: 再起動時のスレッド復旧でworktree存在確認を追加

### DIFF
--- a/test/persistence_integration.test.ts
+++ b/test/persistence_integration.test.ts
@@ -267,16 +267,13 @@ Deno.test("永続化統合テスト - エラー耐性と部分復旧", async () 
       const goodWorker = admin2.getWorker(goodThreadId);
       assertExists(goodWorker);
 
-      // 問題のあるスレッドも Worker は作成されるが、リポジトリ情報の設定で問題が発生する可能性がある
+      // 問題のあるスレッドはworktreeが存在しないためアーカイブされ、Workerは作成されない
       const badWorker = admin2.getWorker(badThreadId);
-      assertExists(badWorker);
-      // parseRepositoryは成功するが、setRepositoryでworktreeの作成に失敗する可能性がある
-      // リポジトリオブジェクト自体は作成される
-
-      // devcontainer設定は復旧される
-      const badConfig = await admin2.getDevcontainerConfig(badThreadId);
-      assertEquals(badConfig?.useDevcontainer, true);
-      assertEquals(badConfig?.containerId, "invalid-container");
+      assertEquals(badWorker, null);
+      
+      // スレッドはアーカイブされている
+      const badThreadInfo = await workspace.loadThreadInfo(badThreadId);
+      assertEquals(badThreadInfo?.status, "archived");
 
       // エラーハンドリングが適切に動作していることを確認
       // 実際のエラーが発生するかは環境に依存するため、ここではWorkerの状態のみを確認


### PR DESCRIPTION
## Summary
- 再起動時のスレッド復旧処理でworktreeの存在確認を追加
- 存在しないworktreeを持つスレッドは自動的にアーカイブされるように改善

## 詳細
プロセス外でworktreeやディレクトリが削除されている可能性に対応するため、スレッド復旧時に以下の確認を実装:

1. **worktreeディレクトリの存在確認**: `Deno.stat()`でファイルシステム上の存在をチェック
2. **git worktreeの有効性確認**: `git worktree list`でgitに登録されているか確認
3. **自動アーカイブ処理**: 存在しないworktreeを持つスレッドは`archived`状態に変更

## 変更内容
- `src/admin.ts`: 
  - `restoreThread()`にworktree存在確認処理を追加
  - `archiveThread()`メソッドを新規追加
- `test/admin.test.ts`: worktree存在確認のテストケースを追加
- `test/persistence_integration.test.ts`: アーカイブ処理を考慮したテストに修正

## Test plan
- [x] 全テストが通過することを確認
- [x] `deno fmt`, `deno check`, `deno lint`で問題がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling during thread restoration to ensure threads with missing or invalid worktree directories are automatically archived, preventing restoration failures.
- **Tests**
	- Updated and added tests to verify that threads without valid worktree directories are archived and not restored, while valid threads are restored correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->