### PR TITLE
feat: TodoWrite成功メッセージのスキップ機能を追加

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -789,9 +789,15 @@ export class Worker implements IWorker {
   ): string | null {
     for (const item of content) {
       if (item.type === "tool_result") {
+        const resultContent = item.content || "";
+        
+        // TodoWrite成功の定型文はスキップ
+        if (!item.is_error && this.isTodoWriteSuccessMessage(resultContent)) {
+          return null;
+        }
+        
         // ツール結果を進捗として投稿
         const resultIcon = item.is_error ? "❌" : "✅";
-        const resultContent = item.content || "";
 
         // 長さに応じて処理を分岐
         const formattedContent = this.formatToolResult(
@@ -1144,6 +1150,23 @@ export class Worker implements IWorker {
       // JSON解析エラーの場合は通常の処理を続行
       return null;
     }
+  }
+
+  /**
+   * TodoWrite成功メッセージかどうかを判定する
+   */
+  private isTodoWriteSuccessMessage(content: string): boolean {
+    // TodoWrite成功時の定型文パターン
+    const successPatterns = [
+      "Todos have been modified successfully",
+      "Todo list has been updated",
+      "Todos updated successfully",
+      "Task list updated successfully"
+    ];
+    
+    return successPatterns.some(pattern => 
+      content.includes(pattern) && content.includes("todo")
+    );
   }
 
   /**

--- a/src/worker_extract_output_test.ts
+++ b/src/worker_extract_output_test.ts
@@ -410,6 +410,82 @@ Deno.test("extractOutputMessage - 短いツール結果を正しく処理する"
   }
 });
 
+Deno.test("extractOutputMessage - TodoWrite成功メッセージをスキップする", async () => {
+  const tempDir = await Deno.makeTempDir();
+  const workspaceManager = new WorkspaceManager(tempDir);
+  await workspaceManager.initialize();
+
+  const worker = new Worker(
+    "test-worker",
+    workspaceManager,
+    new TestClaudeCommandExecutor(),
+  );
+
+  const extractOutputMessage = (worker as unknown as {
+    extractOutputMessage: (parsed: Record<string, unknown>) => string | null;
+  }).extractOutputMessage.bind(worker);
+
+  try {
+    // TodoWrite成功の定型文
+    const todoSuccessMessage = {
+      "type": "user",
+      "message": {
+        "content": [{
+          "type": "tool_result",
+          "content": "Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable",
+          "is_error": false,
+        }],
+      },
+    };
+
+    const result = extractOutputMessage(todoSuccessMessage);
+
+    // TodoWrite成功メッセージはnullを返す（スキップされる）
+    assertEquals(result, null);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("extractOutputMessage - TodoWriteエラーメッセージは表示する", async () => {
+  const tempDir = await Deno.makeTempDir();
+  const workspaceManager = new WorkspaceManager(tempDir);
+  await workspaceManager.initialize();
+
+  const worker = new Worker(
+    "test-worker",
+    workspaceManager,
+    new TestClaudeCommandExecutor(),
+  );
+
+  const extractOutputMessage = (worker as unknown as {
+    extractOutputMessage: (parsed: Record<string, unknown>) => string | null;
+  }).extractOutputMessage.bind(worker);
+
+  try {
+    // TodoWriteエラーメッセージ
+    const todoErrorMessage = {
+      "type": "user",
+      "message": {
+        "content": [{
+          "type": "tool_result",
+          "content": "Error: Failed to update todos - Invalid todo format",
+          "is_error": true,
+        }],
+      },
+    };
+
+    const result = extractOutputMessage(todoErrorMessage);
+
+    // エラーメッセージは表示される
+    assertEquals(typeof result, "string");
+    assertEquals(result?.includes("❌ **ツール実行結果:**"), true);
+    assertEquals(result?.includes("Failed to update todos"), true);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
 Deno.test("extractOutputMessage - 長いツール結果をスマート要約する", async () => {
   const tempDir = await Deno.makeTempDir();
   const workspaceManager = new WorkspaceManager(tempDir);


### PR DESCRIPTION
## Summary
- TodoWrite成功時の定型文メッセージ（"Todos have been modified successfully..."）をDiscordに投稿しないよう修正
- エラーメッセージは引き続き投稿される
- テストケースを追加して動作を検証

## Test plan
- [x] 新しいテストケースを追加
- [x] 全てのテストが通過することを確認（`deno task test`）
- [ ] 実際のDiscord botで動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)