### PR TITLE
fix: resultメッセージの重複送信を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,3 +158,103 @@ const worker = new Worker(name, workspaceManager, claudeExecutor);
 - 各テストで独立したテスト用ディレクトリを使用
 - 適切な権限フラグ（--allow-read --allow-write --allow-env）を指定
 - テスト後のクリーンアップを確実に実行
+
+## Claudeメッセージ処理フロー
+
+### メッセージの種別と処理の流れ
+
+Discord BotがClaudeからのメッセージを処理してDiscordに送信するまでの詳細な流れ：
+
+#### 1. メッセージ受信フロー
+
+```
+Discord User → main.ts (MessageCreate) → admin.routeMessage() → worker.processMessage()
+```
+
+#### 2. Claude実行とストリーミング処理
+
+**Worker.executeClaudeStreaming()** (`src/worker.ts:438-527`)
+
+- Claude CLIをJSON出力モードで実行
+- ストリーミングで1行ずつJSON処理
+- メッセージタイプごとに処理を分岐
+
+#### 3. メッセージタイプ別の処理
+
+**type: "session"**
+
+- セッションIDを記録
+- 初回のみ「🤖 Claudeが考えています...」を送信
+
+**type: "assistant"**
+
+- `extractOutputMessage()`でコンテンツを抽出
+- content配列の各要素を処理：
+  - **text**: そのままテキストとして出力
+  - **tool_use**: `formatToolUse()`でアイコン付きフォーマット
+  - **tool_result**: `formatToolResult()`でスマート要約
+
+**type: "result"**
+
+- 最終結果を処理
+- `formatResponse()`で2000文字制限対応
+
+**type: "error"**
+
+- エラーメッセージをそのまま返却
+- レート制限エラーは特別処理
+
+#### 4. フォーマット関数の詳細
+
+**formatToolUse()** (`src/worker.ts:644-678`)
+
+- ツール名に応じたアイコンを付与：
+  - ⚡ Bash
+  - 📖 Read
+  - ✏️ Edit/Write
+  - 🔍 Glob/Grep
+  - 🌐 WebFetch/WebSearch
+  - 📋 TodoRead
+  - ✅ TodoWrite（特別フォーマット）
+
+**formatToolResult()** (`src/worker.ts:693-758`)
+
+- 結果の長さに応じた処理：
+  - 500文字未満: 全文表示
+  - 500-2000文字: 先頭・末尾表示
+  - 2000文字以上: スマート要約
+- エラー結果は error/fatal 行を優先表示
+
+**formatResponse()** (`src/worker.ts:760-779`)
+
+- Discord文字数制限（2000文字）対応
+- ANSI エスケープコード除去
+- 1900文字で切り詰め + 省略メッセージ
+
+#### 5. Discord送信処理
+
+**main.ts** (`src/main.ts:83-103`)
+
+- 進行中メッセージ: 通知抑制フラグ付き送信
+- 最終応答: ユーザーメンション付き送信
+- レート制限時: ボタン付きメッセージ送信
+
+#### 6. 特殊な処理
+
+**TodoWrite の特別処理**
+
+- チェックリスト形式に変換
+- ✅ 完了、⬜ 未完了、🔄 進行中
+- 成功メッセージは非表示
+
+**レート制限対応**
+
+- DiscordMessage型で返却
+- 自動再開ボタンを提供
+- タイマー永続化機能と連携
+
+**セッションログ記録**
+
+- 全メッセージをWorkspaceManager経由で永続化
+- sessions/{thread_id}/{session_id}.json に保存
+- 再起動後の継続性を保証

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,3 +258,9 @@ Discord User → main.ts (MessageCreate) → admin.routeMessage() → worker.pro
 - 全メッセージをWorkspaceManager経由で永続化
 - sessions/{thread_id}/{session_id}.json に保存
 - 再起動後の継続性を保証
+
+**重要な注意点**
+
+- resultメッセージは進捗として送信されない
+- extractOutputMessageでresultタイプはnullを返す
+- これにより重複送信を防止（以前は3回送信されていた）

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -742,9 +742,9 @@ export class Worker implements IWorker {
       return this.extractUserMessage(parsed.message.content);
     }
 
-    // resultメッセージの場合
-    if (parsed.type === "result" && parsed.result) {
-      return parsed.result;
+    // resultメッセージは最終結果として別途処理されるため、ここでは返さない
+    if (parsed.type === "result") {
+      return null;
     }
 
     // エラーメッセージの場合

--- a/src/worker_extract_output_test.ts
+++ b/src/worker_extract_output_test.ts
@@ -144,7 +144,7 @@ Deno.test("extractOutputMessage - 通常のテキストメッセージを正し�
   }
 });
 
-Deno.test("extractOutputMessage - resultメッセージを正しく処理する", async () => {
+Deno.test("extractOutputMessage - resultメッセージは進捗表示しない", async () => {
   const tempDir = await Deno.makeTempDir();
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
@@ -170,7 +170,8 @@ Deno.test("extractOutputMessage - resultメッセージを正しく処理する"
 
     const result = extractOutputMessage(parsedMessage);
 
-    assertEquals(result, "最終的な結果です。");
+    // resultメッセージは進捗表示せずnullを返す（最終結果として別途処理される）
+    assertEquals(result, null);
   } finally {
     await Deno.remove(tempDir, { recursive: true });
   }

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -317,10 +317,10 @@ Deno.test("Worker - Claude Codeの実際の出力が行ごとに送信される"
   await worker.processMessage("テストメッセージ", onProgress);
 
   // 期待される出力メッセージが送信されたことを確認
+  // result型のメッセージは進捗として送信されないため、それ以外のメッセージを確認
   const expectedMessages = [
     "ファイルを編集しています\n新しい関数を追加しました",
     "テストを実行中...\n✅ すべてのテストが通過しました",
-    "処理が完了しました\n変更内容を確認してください",
   ];
 
   // すべての期待されるメッセージが含まれているかチェック
@@ -331,6 +331,15 @@ Deno.test("Worker - Claude Codeの実際の出力が行ごとに送信される"
       `期待される出力メッセージが見つかりません: ${expectedMessage}`,
     );
   }
+
+  // resultメッセージが進捗として送信されていないことを確認
+  assertEquals(
+    outputMessages.some((msg) =>
+      msg.includes("処理が完了しました\n変更内容を確認してください")
+    ),
+    false,
+    "resultメッセージが進捗として送信されています",
+  );
 });
 
 Deno.test("Worker - エラーメッセージも正しく出力される", async () => {
@@ -375,10 +384,10 @@ Deno.test("Worker - エラーメッセージも正しく出力される", async 
   await worker.processMessage("テストメッセージ", onProgress);
 
   // 期待される出力メッセージが含まれることを確認
+  // result型のメッセージは進捗として送信されないため、それ以外のメッセージを確認
   const expectedMessages = [
     "ファイルを読み込み中...",
     "ファイルが見つかりません\nパスを確認してください",
-    "エラーが発生しました",
   ];
 
   // すべての期待されるメッセージが含まれているかチェック
@@ -389,4 +398,11 @@ Deno.test("Worker - エラーメッセージも正しく出力される", async 
       `期待される出力メッセージが見つかりません: ${expectedMessage}`,
     );
   }
+
+  // resultメッセージが進捗として送信されていないことを確認
+  assertEquals(
+    outputMessages.some((msg) => msg.includes("エラーが発生しました")),
+    false,
+    "resultメッセージが進捗として送信されています",
+  );
 });


### PR DESCRIPTION
## 概要
resultメッセージがDiscordに3回送信される問題を修正しました。

## 問題
- resultメッセージが以下の3箇所で送信されていた：
  1. `extractOutputMessage`で処理され`onProgress`経由で送信
  2. assistantメッセージのテキストとして蓄積される際にも同じ内容が保存
  3. 最終的に`processMessage`の戻り値として再度送信

## 修正内容
- `extractOutputMessage`メソッドでresultタイプの場合はnullを返すように変更
- これによりresultメッセージは進捗として送信されず、最終結果として1回だけ送信される
- 関連するテストを新しい動作に合わせて更新
- CLAUDE.mdに重要な注意点として文書化

## テスト
- worker関連のテストは全てパス
- 既存の1つの失敗テストは本修正とは無関係

## 影響範囲
- メッセージ処理フローのみに影響
- resultメッセージの重複が解消され、Discordへの送信が1回のみになる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added detailed documentation describing the Claude message processing flow, formatting, error handling, and persistence within the Discord Bot system.

- **Bug Fixes**
  - Updated message handling to ensure "result" messages are not shown as progress updates, preventing duplicate or triple sends.

- **Tests**
  - Adjusted and expanded tests to confirm that "result" messages are not displayed as progress updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->