### PR TITLE
feat: メッセージ受信確認とClaude実行開始のリアクション追加

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -228,6 +228,7 @@ export interface IWorker {
   processMessage(
     message: string,
     onProgress?: (content: string) => Promise<void>,
+    onReaction?: (emoji: string) => Promise<void>,
   ): Promise<string>;
   getName(): string;
   getRepository(): GitRepository | null;
@@ -264,6 +265,7 @@ export class Worker implements IWorker {
   async processMessage(
     message: string,
     onProgress: (content: string) => Promise<void> = async () => {},
+    onReaction?: (emoji: string) => Promise<void>,
   ): Promise<string> {
     this.logVerbose("メッセージ処理開始", {
       messageLength: message.length,
@@ -271,6 +273,7 @@ export class Worker implements IWorker {
       hasWorktreePath: !!this.worktreePath,
       threadId: this.threadId,
       sessionId: this.sessionId,
+      hasReactionCallback: !!onReaction,
     });
 
     // VERBOSEモードでユーザーメッセージの詳細ログ
@@ -301,6 +304,18 @@ export class Worker implements IWorker {
       // 処理開始の通知
       this.logVerbose("進捗通知開始");
       await onProgress("🤖 Claudeが考えています...");
+
+      // Claude実行開始前のリアクションを追加
+      if (onReaction) {
+        try {
+          await onReaction("⚙️");
+          this.logVerbose("Claude実行開始リアクション追加完了");
+        } catch (error) {
+          this.logVerbose("Claude実行開始リアクション追加エラー", {
+            error: (error as Error).message,
+          });
+        }
+      }
 
       this.logVerbose("Claude実行開始");
       const result = await this.executeClaude(message, onProgress);

--- a/test/admin.test.ts
+++ b/test/admin.test.ts
@@ -76,7 +76,12 @@ Deno.test("Admin - スレッドにメッセージをルーティングできる"
   const message = "テストメッセージ";
 
   await admin.createWorker(threadId);
-  const reply = await admin.routeMessage(threadId, message);
+  const reply = await admin.routeMessage(
+    threadId,
+    message,
+    undefined,
+    undefined,
+  );
 
   assertExists(reply);
   // 新しい実装では、リポジトリ未設定時の固定メッセージが返される
@@ -91,7 +96,7 @@ Deno.test("Admin - 存在しないスレッドへのメッセージはエラー�
   const admin = new Admin(workspace);
 
   try {
-    await admin.routeMessage("non-existent", "test");
+    await admin.routeMessage("non-existent", "test", undefined, undefined);
     assertEquals(true, false, "エラーが発生するはず");
   } catch (error) {
     assertEquals(

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -29,7 +29,12 @@ Deno.test("統合テスト - Admin経由でWorkerとやり取りできる", asyn
   ];
 
   for (const message of messages) {
-    const reply = await admin.routeMessage(threadId, message);
+    const reply = await admin.routeMessage(
+      threadId,
+      message,
+      undefined,
+      undefined,
+    );
     assertEquals(
       reply,
       "リポジトリが設定されていません。/start コマンドでリポジトリを指定してください。",
@@ -52,7 +57,7 @@ Deno.test("統合テスト - 複数のスレッドを同時に処理できる", 
   // 各スレッドにメッセージを送信
   const message = "マルチスレッドテスト";
   const promises = threadIds.map((threadId) =>
-    admin.routeMessage(threadId, message)
+    admin.routeMessage(threadId, message, undefined, undefined)
   );
 
   const replies = await Promise.all(promises);


### PR DESCRIPTION
## Summary
- Discord botがメッセージを受信したタイミングで👀リアクションを追加
- Claude実行を開始する直前に⚙️リアクションを追加  
- レートリミット後の自動再開時も同様のリアクション機能を追加

これにより、botがメッセージを受け取ったことと、Claude処理を開始したことがユーザーに視覚的にフィードバックされます。

## Test plan
- [ ] Discord botを起動して、スレッドにメッセージを送信
- [ ] メッセージにすぐに👀リアクションがつくことを確認
- [ ] その後、⚙️リアクションが追加されることを確認
- [ ] Claude処理が完了して応答が返ることを確認
- [ ] レートリミット自動再開時も同様のリアクションが動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for emoji reactions to messages, providing visual feedback such as message receipt and processing status.
  - Enhanced message replies to distinguish between plain text and structured responses with components.
- **Bug Fixes**
  - Improved error handling when adding emoji reactions to messages.
- **Tests**
  - Updated tests to accommodate the new reaction callback functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->