### PR TITLE
feat: スレッド終了時にDiscordスレッドを自動クローズする機能追加

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,19 @@ const client = new Client({
   ],
 });
 
+// スレッドクローズコールバックを設定
+admin.setThreadCloseCallback(async (threadId: string) => {
+  try {
+    const thread = await client.channels.fetch(threadId);
+    if (thread && thread.isThread()) {
+      await thread.setArchived(true);
+      console.log(`スレッド ${threadId} をアーカイブしました`);
+    }
+  } catch (error) {
+    console.error(`スレッド ${threadId} のアーカイブに失敗:`, error);
+  }
+});
+
 // スラッシュコマンドの定義
 const commands = [
   new SlashCommandBuilder()

--- a/test/admin.test.ts
+++ b/test/admin.test.ts
@@ -144,6 +144,29 @@ Deno.test("Admin - 終了ボタンでスレッドを終了できる", async () =
   assertEquals(threadInfo?.status, "archived");
 });
 
+Deno.test("Admin - スレッドクローズコールバックが呼ばれる", async () => {
+  const workspace = await createTestWorkspaceManager();
+  const admin = new Admin(workspace);
+  const threadId = "thread-callback-test";
+
+  let callbackCalled = false;
+  let callbackThreadId = "";
+
+  admin.setThreadCloseCallback(async (tid: string) => {
+    callbackCalled = true;
+    callbackThreadId = tid;
+  });
+
+  await admin.createWorker(threadId);
+  assertExists(admin.getWorker(threadId));
+
+  await admin.terminateThread(threadId);
+
+  assertEquals(callbackCalled, true);
+  assertEquals(callbackThreadId, threadId);
+  assertEquals(admin.getWorker(threadId), null);
+});
+
 Deno.test("Admin - 未知のボタンIDの場合は適切なメッセージを返す", async () => {
   const workspace = await createTestWorkspaceManager();
   const admin = new Admin(workspace);


### PR DESCRIPTION
## Summary
- スレッド終了ボタンを押したときに、Discord上のスレッドも自動的にクローズ（アーカイブ）されるようになりました
- Adminクラスにコールバック機構を追加し、main.tsでDiscord APIを使用してスレッドをアーカイブ

## Test plan
- [x] 新しいテストケースを追加（スレッドクローズコールバックが呼ばれることを確認）
- [x] 既存のテストがすべてパス（一部フレーキーなテストを除く）
- [ ] 実際のDiscord環境でスレッド終了ボタンを押してスレッドがアーカイブされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Threads are now automatically archived in Discord when closed.
- **Tests**
	- Added a new test to verify that the thread close callback is triggered correctly during thread termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->