### PR TITLE
fix: スレッド終了時の処理順序を修正（ボタン削除→アーカイブ）

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import {
   AutocompleteInteraction,
   ButtonInteraction,
+  ChannelType,
   ChatInputCommandInteraction,
   Client,
   Events,
@@ -9,6 +10,7 @@ import {
   Routes,
   SlashCommandBuilder,
   TextChannel,
+  ThreadChannel,
 } from "discord.js";
 import { Admin } from "./admin.ts";
 import { Worker } from "./worker.ts";
@@ -143,6 +145,19 @@ client.once(Events.ClientReady, async (readyClient) => {
       }
     } catch (error) {
       console.error("自動再開メッセージ送信エラー:", error);
+    }
+  });
+
+  // スレッドクローズコールバックを設定
+  admin.setThreadCloseCallback(async (threadId: string) => {
+    try {
+      const channel = await readyClient.channels.fetch(threadId);
+      if (channel && channel.type === ChannelType.PublicThread) {
+        await (channel as ThreadChannel).setArchived(true);
+        console.log(`スレッドをアーカイブしました: ${threadId}`);
+      }
+    } catch (error) {
+      console.error(`スレッドのアーカイブに失敗しました (${threadId}):`, error);
     }
   });
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -234,6 +234,8 @@ export interface IWorker {
   getRepository(): GitRepository | null;
   setRepository(repository: GitRepository, localPath: string): Promise<void>;
   setThreadId(threadId: string): void;
+  isUsingDevcontainer(): boolean;
+  isSkipPermissions(): boolean;
 }
 
 export class Worker implements IWorker {

--- a/test/admin.test.ts
+++ b/test/admin.test.ts
@@ -769,10 +769,8 @@ Deno.test("Admin - devcontainer設定がWorkerに正しく復旧される", asyn
 
   // Worker内のdevcontainer設定が復旧されていることを確認
   if (worker) {
-    // Workerの型をキャストしてメソッドにアクセス
-    const workerImpl = worker as any;
-    assertEquals(workerImpl.isUsingDevcontainer(), true);
-    assertEquals(workerImpl.isSkipPermissions(), true);
+    assertEquals(worker.isUsingDevcontainer(), true);
+    assertEquals(worker.isSkipPermissions(), true);
   }
 
   // devcontainer設定がAdminからも取得できることを確認
@@ -817,9 +815,8 @@ Deno.test("Admin - devcontainer設定未設定スレッドの復旧", async () =
 
   // Worker内のdevcontainer設定がデフォルト値であることを確認
   if (worker) {
-    const workerImpl = worker as any;
-    assertEquals(workerImpl.isUsingDevcontainer(), false);
-    assertEquals(workerImpl.isSkipPermissions(), false);
+    assertEquals(worker.isUsingDevcontainer(), false);
+    assertEquals(worker.isSkipPermissions(), false);
   }
 
   // devcontainer設定がnullであることを確認


### PR DESCRIPTION
## Summary
- スレッド終了ボタンを押した際に、ボタンを削除してからスレッドをアーカイブするように処理順序を修正
- setThreadCloseCallbackの実装を追加し、スレッドのアーカイブ処理を適切に実行

## 変更内容
1. main.tsにsetThreadCloseCallbackの実装を追加
   - ChannelTypeとThreadChannelのインポートを追加
   - スレッドをアーカイブする処理を実装
2. IWorkerインターフェースにメソッドを追加
   - isUsingDevcontainer()とisSkipPermissions()をインターフェースに追加
   - テストでのany型使用を排除

## 解決した問題
Discord APIからのエラーを解消しました。以前はスレッドをアーカイブしてからボタンを削除しようとしていたため、アーカイブされたスレッドのメッセージを編集できないというエラーが発生していました。

## Test plan
- [x] deno fmt でフォーマットチェック
- [x] deno lint でlintチェック  
- [x] deno check でタイプチェック
- [x] deno test で全テストが通過

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Threads can now be automatically archived when closed, with improved type checking and logging for thread management.

- **Tests**
  - Simplified test code for verifying worker devcontainer and permission settings, improving readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->