### PR TITLE
refactor: モッククラスを関数ベースに変更し、不要なinterface定義を削除

### DIFF
--- a/src/worker_devcontainer_test.ts
+++ b/src/worker_devcontainer_test.ts
@@ -2,28 +2,7 @@ import { assertEquals } from "std/assert/mod.ts";
 import { Worker } from "./worker.ts";
 import { WorkspaceManager } from "./workspace.ts";
 import { parseRepository } from "./git-utils.ts";
-
-// モック用のClaudeCommandExecutor
-class MockClaudeExecutor {
-  async executeStreaming(
-    _args: string[],
-    _cwd: string,
-    onData: (data: Uint8Array) => void,
-  ): Promise<{ code: number; stderr: Uint8Array }> {
-    const response = JSON.stringify({
-      type: "result",
-      result: "Claude からのテスト応答",
-    });
-
-    // ストリーミングをシミュレート
-    onData(new TextEncoder().encode(response));
-
-    return {
-      code: 0,
-      stderr: new TextEncoder().encode(""),
-    };
-  }
-}
+import { createMockClaudeCommandExecutor } from "../test/test-utils.ts";
 
 Deno.test("Worker devcontainer機能のテスト", async (t) => {
   const tempDir = await Deno.makeTempDir();
@@ -37,7 +16,7 @@ Deno.test("Worker devcontainer機能のテスト", async (t) => {
     worker = new Worker(
       "test-worker",
       workspaceManager,
-      new MockClaudeExecutor(),
+      createMockClaudeCommandExecutor("Claude からのテスト応答"),
     );
     worker.setThreadId("test-thread-123");
 

--- a/src/worker_extract_output_test.ts
+++ b/src/worker_extract_output_test.ts
@@ -1,17 +1,7 @@
 import { assertEquals } from "https://deno.land/std@0.208.0/testing/asserts.ts";
 import { Worker } from "./worker.ts";
 import { WorkspaceManager } from "./workspace.ts";
-
-// テスト用のClaudeCommandExecutor
-class TestClaudeCommandExecutor {
-  async executeStreaming(
-    _args: string[],
-    _cwd: string,
-    _onData: (data: Uint8Array) => void,
-  ): Promise<{ code: number; stderr: Uint8Array }> {
-    return { code: 0, stderr: new Uint8Array() };
-  }
-}
+import { createMockClaudeCommandExecutor } from "../test/test-utils.ts";
 
 Deno.test("extractOutputMessage - TODOリスト更新（tool_use）を正しく処理する", async () => {
   const tempDir = await Deno.makeTempDir();
@@ -21,7 +11,7 @@ Deno.test("extractOutputMessage - TODOリスト更新（tool_use）を正しく�
   const worker = new Worker(
     "test-worker",
     workspaceManager,
-    new TestClaudeCommandExecutor(),
+    createMockClaudeCommandExecutor(),
   );
 
   // Worker クラスの private メソッドにアクセスするためのヘルパー
@@ -110,7 +100,7 @@ Deno.test("extractOutputMessage - 通常のテキストメッセージを正し�
   const worker = new Worker(
     "test-worker",
     workspaceManager,
-    new TestClaudeCommandExecutor(),
+    createMockClaudeCommandExecutor(),
   );
 
   const extractOutputMessage = (worker as unknown as {
@@ -152,7 +142,7 @@ Deno.test("extractOutputMessage - resultメッセージは進捗表示しない"
   const worker = new Worker(
     "test-worker",
     workspaceManager,
-    new TestClaudeCommandExecutor(),
+    createMockClaudeCommandExecutor(),
   );
 
   const extractOutputMessage = (worker as unknown as {
@@ -185,7 +175,7 @@ Deno.test("extractOutputMessage - エラーメッセージを正しく処理す�
   const worker = new Worker(
     "test-worker",
     workspaceManager,
-    new TestClaudeCommandExecutor(),
+    createMockClaudeCommandExecutor(),
   );
 
   const extractOutputMessage = (worker as unknown as {
@@ -223,7 +213,7 @@ Deno.test("extractTodoListUpdate - fallback処理でテキストからTODOリス
   const worker = new Worker(
     "test-worker",
     workspaceManager,
-    new TestClaudeCommandExecutor(),
+    createMockClaudeCommandExecutor(),
   );
 
   const extractTodoListUpdate = (worker as unknown as {
@@ -259,7 +249,7 @@ Deno.test("extractOutputMessage - Bashツール実行を正しく処理する", 
   const worker = new Worker(
     "test-worker",
     workspaceManager,
-    new TestClaudeCommandExecutor(),
+    createMockClaudeCommandExecutor(),
   );
 
   const extractOutputMessage = (worker as unknown as {
@@ -300,7 +290,7 @@ Deno.test("extractOutputMessage - ツール結果（tool_result）を正しく�
   const worker = new Worker(
     "test-worker",
     workspaceManager,
-    new TestClaudeCommandExecutor(),
+    createMockClaudeCommandExecutor(),
   );
 
   const extractOutputMessage = (worker as unknown as {
@@ -341,7 +331,7 @@ Deno.test("extractOutputMessage - エラーツール結果を正しく処理す�
   const worker = new Worker(
     "test-worker",
     workspaceManager,
-    new TestClaudeCommandExecutor(),
+    createMockClaudeCommandExecutor(),
   );
 
   const extractOutputMessage = (worker as unknown as {
@@ -381,7 +371,7 @@ Deno.test("extractOutputMessage - 短いツール結果を正しく処理する"
   const worker = new Worker(
     "test-worker",
     workspaceManager,
-    new TestClaudeCommandExecutor(),
+    createMockClaudeCommandExecutor(),
   );
 
   const extractOutputMessage = (worker as unknown as {
@@ -419,7 +409,7 @@ Deno.test("extractOutputMessage - TodoWrite成功メッセージをスキップ�
   const worker = new Worker(
     "test-worker",
     workspaceManager,
-    new TestClaudeCommandExecutor(),
+    createMockClaudeCommandExecutor(),
   );
 
   const extractOutputMessage = (worker as unknown as {
@@ -457,7 +447,7 @@ Deno.test("extractOutputMessage - TodoWriteエラーメッセージは表示す�
   const worker = new Worker(
     "test-worker",
     workspaceManager,
-    new TestClaudeCommandExecutor(),
+    createMockClaudeCommandExecutor(),
   );
 
   const extractOutputMessage = (worker as unknown as {
@@ -496,7 +486,7 @@ Deno.test("extractOutputMessage - 長いツール結果をスマート要約す�
   const worker = new Worker(
     "test-worker",
     workspaceManager,
-    new TestClaudeCommandExecutor(),
+    createMockClaudeCommandExecutor(),
   );
 
   const extractOutputMessage = (worker as unknown as {
@@ -545,7 +535,7 @@ Deno.test("extractOutputMessage - エラー結果から重要部分を抽出す�
   const worker = new Worker(
     "test-worker",
     workspaceManager,
-    new TestClaudeCommandExecutor(),
+    createMockClaudeCommandExecutor(),
   );
 
   const extractOutputMessage = (worker as unknown as {
@@ -598,7 +588,7 @@ Deno.test("extractOutputMessage - 中程度の長さの結果を先頭末尾で�
   const worker = new Worker(
     "test-worker",
     workspaceManager,
-    new TestClaudeCommandExecutor(),
+    createMockClaudeCommandExecutor(),
   );
 
   const extractOutputMessage = (worker as unknown as {

--- a/test/admin.test.ts
+++ b/test/admin.test.ts
@@ -770,7 +770,8 @@ Deno.test("Admin - devcontainer設定がWorkerに正しく復旧される", asyn
   // Worker内のdevcontainer設定が復旧されていることを確認
   if (worker) {
     // Workerの型をキャストしてメソッドにアクセス
-    const workerImpl = worker as any;
+    const { Worker } = await import("../src/worker.ts");
+    const workerImpl = worker as InstanceType<typeof Worker>;
     assertEquals(workerImpl.isUsingDevcontainer(), true);
     assertEquals(workerImpl.isSkipPermissions(), true);
   }
@@ -817,7 +818,8 @@ Deno.test("Admin - devcontainer設定未設定スレッドの復旧", async () =
 
   // Worker内のdevcontainer設定がデフォルト値であることを確認
   if (worker) {
-    const workerImpl = worker as any;
+    const { Worker } = await import("../src/worker.ts");
+    const workerImpl = worker as InstanceType<typeof Worker>;
     assertEquals(workerImpl.isUsingDevcontainer(), false);
     assertEquals(workerImpl.isSkipPermissions(), false);
   }

--- a/test/worker-streaming.test.ts
+++ b/test/worker-streaming.test.ts
@@ -1,9 +1,9 @@
 import { assertEquals } from "std/assert/mod.ts";
 import { Worker } from "../src/worker.ts";
 import {
+  createMockStreamingClaudeCommandExecutor,
   createTestRepository,
   createTestWorkspaceManager,
-  MockStreamingClaudeCommandExecutor,
 } from "./test-utils.ts";
 
 Deno.test("Worker - ストリーミング進捗コールバックが呼ばれる", async () => {
@@ -19,8 +19,7 @@ Deno.test("Worker - ストリーミング進捗コールバックが呼ばれる
       '{"type":"result","result":"完了しました。"}\n',
     ];
 
-    const mockExecutor = new MockStreamingClaudeCommandExecutor();
-    mockExecutor.streamingEnabled = true;
+    const mockExecutor = createMockStreamingClaudeCommandExecutor();
 
     // ストリーミングデータを設定
     const allData = streamData.join("");
@@ -65,8 +64,7 @@ Deno.test("Worker - エラー時のストリーミング処理", async () => {
       '{"type":"error","error":"エラーが発生しました"}\n',
     ];
 
-    const mockExecutor = new MockStreamingClaudeCommandExecutor();
-    mockExecutor.streamingEnabled = true;
+    const mockExecutor = createMockStreamingClaudeCommandExecutor();
 
     // エラーを返すように設定
     const allData = streamData.join("");
@@ -108,8 +106,7 @@ Deno.test("Worker - 進捗コールバックなしでも動作する", async () 
       '{"type":"result","result":"完了"}\n',
     ];
 
-    const mockExecutor = new MockStreamingClaudeCommandExecutor();
-    mockExecutor.streamingEnabled = true;
+    const mockExecutor = createMockStreamingClaudeCommandExecutor();
 
     const allData = streamData.join("");
     mockExecutor.setResponse("no callback test", allData);

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -3,18 +3,18 @@ import { Worker } from "../src/worker.ts";
 import { parseRepository } from "../src/git-utils.ts";
 import {
   captureConsoleOutput,
+  createMockClaudeCommandExecutor,
+  createMockStreamingClaudeCommandExecutor,
   createTestRepository,
   createTestWorker,
   createTestWorkspaceManager,
   ERROR_MESSAGES,
-  MockClaudeCommandExecutor,
-  MockStreamingClaudeCommandExecutor,
 } from "./test-utils.ts";
 
 Deno.test("Worker - メッセージを受け取って返信する（リポジトリ未設定）", async () => {
   const workspace = await createTestWorkspaceManager();
   const workerName = "happy-panda";
-  const executor = new MockClaudeCommandExecutor();
+  const executor = createMockClaudeCommandExecutor();
 
   try {
     const worker = await createTestWorker(workerName, workspace, executor);
@@ -41,7 +41,7 @@ Deno.test("Worker - 名前を取得できる", async () => {
 
 Deno.test("Worker - 空のメッセージも処理できる", async () => {
   const workspace = await createTestWorkspaceManager();
-  const executor = new MockClaudeCommandExecutor();
+  const executor = createMockClaudeCommandExecutor();
 
   try {
     const worker = await createTestWorker("test-worker", workspace, executor);
@@ -74,7 +74,7 @@ Deno.test("Worker - リポジトリ情報を設定・取得できる", async () 
 Deno.test("Worker - リポジトリ設定後のメッセージ処理", async () => {
   const workspace = await createTestWorkspaceManager();
   const mockResponse = "これはリポジトリ設定後のモック応答です。";
-  const executor = new MockClaudeCommandExecutor(mockResponse);
+  const executor = createMockClaudeCommandExecutor(mockResponse);
 
   try {
     const worker = await createTestWorker("test-worker", workspace, executor);
@@ -117,7 +117,7 @@ Deno.test("Worker - verboseモードが正しく設定される", async () => {
 
 Deno.test("Worker - verboseモードでログが出力される", async () => {
   const workspace = await createTestWorkspaceManager();
-  const executor = new MockClaudeCommandExecutor();
+  const executor = createMockClaudeCommandExecutor();
 
   let logOutput = "";
   const originalLog = console.log;
@@ -165,8 +165,7 @@ Deno.test("Worker - Claude Codeの実際の出力が行ごとに送信される"
   const repository = parseRepository("test/repo");
   const repoPath = "/test/repo";
 
-  const mockExecutor = new MockStreamingClaudeCommandExecutor();
-  mockExecutor.streamingEnabled = true;
+  const mockExecutor = createMockStreamingClaudeCommandExecutor();
   // モックレスポンスは最終的に"モックレスポンス"を返す
   mockExecutor.setResponse("test", "モックレスポンス");
 


### PR DESCRIPTION
## Summary
- TestContext interfaceを削除し、インライン型定義に変更
- MockClaudeCommandExecutor等のクラスを関数ベースのファクトリーパターンに変更
- 全てのテストが正常に動作することを確認

## Test plan
- [x] `deno fmt` でフォーマットを確認
- [x] `deno check **/*.ts` で型チェックを確認
- [x] `deno lint` でlintエラーがないことを確認
- [x] `deno test --allow-read --allow-write --allow-env --allow-run` で全テストが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)