### PR TITLE
feat: JSON断片が進捗メッセージとして投稿されないよう修正

### DIFF
--- a/test/admin.test.ts
+++ b/test/admin.test.ts
@@ -3,6 +3,7 @@ import {
   assertExists,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import { Admin } from "../src/admin.ts";
+import { Worker } from "../src/worker.ts";
 import {
   assertWorkerValid,
   createTestContext,
@@ -769,8 +770,8 @@ Deno.test("Admin - devcontainer設定がWorkerに正しく復旧される", asyn
 
   // Worker内のdevcontainer設定が復旧されていることを確認
   if (worker) {
-    // Workerの型をキャストしてメソッドにアクセス
-    const workerImpl = worker as any;
+    // WorkerはIWorkerインターフェースを実装しているため、実際のWorkerクラスにキャスト
+    const workerImpl = worker as Worker;
     assertEquals(workerImpl.isUsingDevcontainer(), true);
     assertEquals(workerImpl.isSkipPermissions(), true);
   }
@@ -817,7 +818,7 @@ Deno.test("Admin - devcontainer設定未設定スレッドの復旧", async () =
 
   // Worker内のdevcontainer設定がデフォルト値であることを確認
   if (worker) {
-    const workerImpl = worker as any;
+    const workerImpl = worker as Worker;
     assertEquals(workerImpl.isUsingDevcontainer(), false);
     assertEquals(workerImpl.isSkipPermissions(), false);
   }

--- a/test/worker-json-fragment.test.ts
+++ b/test/worker-json-fragment.test.ts
@@ -1,0 +1,146 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { Worker } from "../src/worker.ts";
+import { WorkspaceManager } from "../src/workspace.ts";
+import { ClaudeCommandExecutor } from "../src/worker.ts";
+
+// 不完全なJSON断片を送信するモック
+class JsonFragmentStreamExecutor implements ClaudeCommandExecutor {
+  async executeStreaming(
+    _args: string[],
+    _cwd: string,
+    onData: (data: Uint8Array) => void,
+  ): Promise<{ code: number; stderr: Uint8Array }> {
+    const encoder = new TextEncoder();
+
+    // 完全なJSON
+    onData(encoder.encode('{"type":"session","session_id":"test-session"}\n'));
+
+    // 部分的なJSON（改行で終わるがJSON解析エラーになる）
+    onData(
+      encoder.encode(
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"これは\n',
+      ),
+    );
+    onData(encoder.encode('長いテキストです"}]}}\n'));
+
+    // 通常のエラーメッセージ（JSONではない）
+    onData(encoder.encode("Error: This is a normal error message\n"));
+
+    // 最終結果
+    onData(encoder.encode('{"type":"result","result":"完了"}\n'));
+
+    return { code: 0, stderr: new Uint8Array() };
+  }
+}
+
+Deno.test("JSON断片が長大なログ行で投稿されない", async () => {
+  const tempDir = await Deno.makeTempDir();
+
+  try {
+    const workspaceManager = new WorkspaceManager(tempDir);
+    await workspaceManager.initialize();
+
+    const mockExecutor = new JsonFragmentStreamExecutor();
+    const worker = new Worker("test-worker", workspaceManager, mockExecutor);
+    worker.setThreadId("test-thread");
+    await worker.setRepository(
+      { org: "test", repo: "repo", fullName: "test/repo", localPath: tempDir },
+      tempDir,
+    );
+
+    const progressMessages: string[] = [];
+    await worker.processMessage(
+      "テストメッセージ",
+      async (content) => {
+        progressMessages.push(content);
+      },
+    );
+
+    // JSON断片が投稿されていないことを確認
+    for (const message of progressMessages) {
+      assertEquals(
+        message.includes(
+          '{"type":"assistant","message":{"content":[{"type":"text","text":"これは',
+        ),
+        false,
+        "不完全なJSON断片が投稿されています",
+      );
+    }
+
+    // 通常のエラーメッセージは投稿されることを確認
+    const hasErrorMessage = progressMessages.some((msg) =>
+      msg.includes("Error: This is a normal error message")
+    );
+    assertEquals(
+      hasErrorMessage,
+      true,
+      "通常のエラーメッセージが投稿されていません",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+// 長大な一行JSONのテスト
+class SingleLineLongJsonExecutor implements ClaudeCommandExecutor {
+  async executeStreaming(
+    _args: string[],
+    _cwd: string,
+    onData: (data: Uint8Array) => void,
+  ): Promise<{ code: number; stderr: Uint8Array }> {
+    const encoder = new TextEncoder();
+
+    // 非常に長い一行のJSON（10MB以上）
+    const longText = "A".repeat(10 * 1024 * 1024); // 10MB
+    const longJson =
+      `{"type":"assistant","message":{"content":[{"type":"text","text":"${longText}"}]}}\n`;
+
+    // チャンクに分けて送信
+    const chunkSize = 1024 * 1024; // 1MB chunks
+    for (let i = 0; i < longJson.length; i += chunkSize) {
+      onData(
+        encoder.encode(
+          longJson.slice(i, Math.min(i + chunkSize, longJson.length)),
+        ),
+      );
+    }
+
+    onData(encoder.encode('{"type":"result","result":"完了"}\n'));
+
+    return { code: 0, stderr: new Uint8Array() };
+  }
+}
+
+Deno.test("非常に長い一行JSONが正しく処理される", async () => {
+  const tempDir = await Deno.makeTempDir();
+
+  try {
+    const workspaceManager = new WorkspaceManager(tempDir);
+    await workspaceManager.initialize();
+
+    const mockExecutor = new SingleLineLongJsonExecutor();
+    const worker = new Worker("test-worker", workspaceManager, mockExecutor);
+    worker.setThreadId("test-thread");
+    await worker.setRepository(
+      { org: "test", repo: "repo", fullName: "test/repo", localPath: tempDir },
+      tempDir,
+    );
+
+    const progressMessages: string[] = [];
+    const result = await worker.processMessage(
+      "テストメッセージ",
+      async (content) => {
+        progressMessages.push(content);
+      },
+    );
+
+    // 長いテキストが正しく処理されていることを確認
+    const hasLongText = progressMessages.some((msg) => msg.includes("AAAA"));
+    assertEquals(hasLongText, true, "長いテキストが処理されていません");
+
+    // 結果が正しく取得できていることを確認
+    assertEquals(result, "完了");
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary
- 不完全なJSON断片が進捗メッセージとして投稿される問題を修正
- 通常のエラーメッセージは引き続き投稿されるよう設計

## Test plan
- [x] JSON断片処理のテストを追加 (`test/worker-json-fragment.test.ts`)
- [x] 不完全なJSON断片がスキップされることを確認
- [x] 通常のエラーメッセージが投稿されることを確認
- [x] 長大な一行JSONが正しく処理されることを確認
- [x] 全テストが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling to prevent incomplete or partial JSON fragments from being shown in progress updates during streaming output.

- **Tests**
	- Added new tests to ensure incomplete JSON fragments are not emitted and that very large JSON messages are handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->