### PR TITLE
fix: Devcontainerオプション選択時にDevcontainerExecutorが正しく設定されない問題を修正

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -483,6 +483,7 @@
     "https://deno.land/std@0.224.0/path/windows/resolve.ts": "8dae1dadfed9d46ff46cc337c9525c0c7d959fb400a6308f34595c45bdca1972",
     "https://deno.land/std@0.224.0/path/windows/to_file_url.ts": "40e560ee4854fe5a3d4d12976cef2f4e8914125c81b11f1108e127934ced502e",
     "https://deno.land/std@0.224.0/path/windows/to_namespaced_path.ts": "4ffa4fb6fae321448d5fe810b3ca741d84df4d7897e61ee29be961a6aac89a4c",
+    "https://deno.land/std@0.224.0/testing/asserts.ts": "d0cdbabadc49cc4247a50732ee0df1403fdcd0f95360294ad448ae8c240f3f5c",
     "https://deno.land/std@0.224.0/yaml/_dumper/dumper.ts": "08b595b40841a2e1c75303f5096392323b6baf8e9662430a91e3b36fbe175fe9",
     "https://deno.land/std@0.224.0/yaml/_dumper/dumper_state.ts": "9e29f700ea876ed230b43f11fa006fcb1a62eedc1e27d32baaeaf3210f19f1e7",
     "https://deno.land/std@0.224.0/yaml/_error.ts": "f38cdebdb69cde16903d9aa2f3b8a3dd9d13e5f7f3570bf662bfaca69fef669e",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1286,6 +1286,17 @@ export class Worker implements IWorker {
 
     if (result.success) {
       this.devcontainerStarted = true;
+
+      // DevcontainerClaudeExecutorに切り替え
+      if (this.useDevcontainer && this.worktreePath) {
+        this.logVerbose(
+          "DevcontainerClaudeExecutorに切り替え（startDevcontainer成功後）",
+        );
+        this.claudeExecutor = new DevcontainerClaudeExecutor(
+          this.worktreePath,
+          this.verbose,
+        );
+      }
     }
 
     return result;


### PR DESCRIPTION
## Summary
- Devcontainerオプション選択時に、DevcontainerExecutorへの切り替えが正しく行われない問題を修正
- startDevcontainer成功後にExecutorの切り替え処理を追加

## 問題の詳細
Devcontainerオプションを選択しても、Claude CodeがDevcontainer環境で実行されず、ローカル環境で実行されてしまう問題がありました。

### 原因
1. `setRepository`メソッドでのみDevcontainerExecutorへの切り替えが行われていた
2. Devcontainerオプション選択時のフローでは、既にリポジトリ設定が完了してから`startDevcontainer`が呼ばれるため、Executorの切り替えが発生しなかった
3. 再起動時の復旧処理では正しく動作していたが、通常のフローでは問題があった

### 修正内容
`Worker.startDevcontainer`メソッドで、コンテナ起動成功後にDevcontainerClaudeExecutorへの切り替えを行うようにしました。

```typescript
if (result.success) {
  this.devcontainerStarted = true;
  
  // DevcontainerClaudeExecutorに切り替え
  if (this.useDevcontainer && this.worktreePath) {
    this.logVerbose("DevcontainerClaudeExecutorに切り替え（startDevcontainer成功後）");
    this.claudeExecutor = new DevcontainerClaudeExecutor(
      this.worktreePath,
      this.verbose,
    );
  }
}
```

## Test plan
- [x] 既存のdevcontainerストリーミングテストが正常に動作することを確認
- [x] 永続化統合テストが正常に動作することを確認
- [x] lint、型チェック、フォーマットチェックをクリア

🤖 Generated with [Claude Code](https://claude.ai/code)