### PR TITLE
fix: Discord投稿でフルパスではなく相対パスを表示するように修正

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1082,6 +1082,36 @@ export class Worker implements IWorker {
   }
 
   /**
+   * ファイルパスから作業ディレクトリを除外した相対パスを取得
+   */
+  private getRelativePath(filePath: string): string {
+    if (!filePath) return "";
+
+    // worktreePathが設定されている場合はそれを基準に
+    if (this.worktreePath && filePath.startsWith(this.worktreePath)) {
+      return filePath.slice(this.worktreePath.length).replace(/^\//, "");
+    }
+
+    // worktreePathがない場合は、リポジトリのパスパターンを探す
+    const repoPattern = /\/repositories\/[^\/]+\/[^\/]+\//;
+    const match = filePath.match(repoPattern);
+    if (match && match.index !== undefined) {
+      // リポジトリディレクトリ以降のパスを返す
+      return filePath.slice(match.index + match[0].length);
+    }
+
+    // threadsディレクトリのパターンも探す
+    const threadsPattern = /\/threads\/[^\/]+\/worktree\//;
+    const threadsMatch = filePath.match(threadsPattern);
+    if (threadsMatch && threadsMatch.index !== undefined) {
+      // worktreeディレクトリ以降のパスを返す
+      return filePath.slice(threadsMatch.index + threadsMatch[0].length);
+    }
+
+    return filePath;
+  }
+
+  /**
    * ツール名に対応するアイコンを取得
    */
   private getToolIcon(toolName: string): string {
@@ -1128,19 +1158,29 @@ export class Worker implements IWorker {
         return "コマンド実行";
       }
       case "Read":
-        return `ファイル読み込み: ${input?.file_path || ""}`;
+        return `ファイル読み込み: ${
+          this.getRelativePath(input?.file_path as string || "")
+        }`;
       case "Write":
-        return `ファイル書き込み: ${input?.file_path || ""}`;
+        return `ファイル書き込み: ${
+          this.getRelativePath(input?.file_path as string || "")
+        }`;
       case "Edit":
-        return `ファイル編集: ${input?.file_path || ""}`;
+        return `ファイル編集: ${
+          this.getRelativePath(input?.file_path as string || "")
+        }`;
       case "MultiEdit":
-        return `ファイル一括編集: ${input?.file_path || ""}`;
+        return `ファイル一括編集: ${
+          this.getRelativePath(input?.file_path as string || "")
+        }`;
       case "Glob":
         return `ファイル検索: ${input?.pattern || ""}`;
       case "Grep":
         return `コンテンツ検索: ${input?.pattern || ""}`;
       case "LS":
-        return `ディレクトリ一覧: ${input?.path || ""}`;
+        return `ディレクトリ一覧: ${
+          this.getRelativePath(input?.path as string || "")
+        }`;
       case "Task":
         return `エージェントタスク: ${input?.description || ""}`;
       case "WebFetch":
@@ -1148,9 +1188,13 @@ export class Worker implements IWorker {
       case "WebSearch":
         return `Web検索: ${input?.query || ""}`;
       case "NotebookRead":
-        return `ノートブック読み込み: ${input?.notebook_path || ""}`;
+        return `ノートブック読み込み: ${
+          this.getRelativePath(input?.notebook_path as string || "")
+        }`;
       case "NotebookEdit":
-        return `ノートブック編集: ${input?.notebook_path || ""}`;
+        return `ノートブック編集: ${
+          this.getRelativePath(input?.notebook_path as string || "")
+        }`;
       case "TodoRead":
         return "TODOリスト確認";
       default:

--- a/test/worker-relative-path.test.ts
+++ b/test/worker-relative-path.test.ts
@@ -1,0 +1,149 @@
+import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
+import { Worker } from "../src/worker.ts";
+import { WorkspaceManager } from "../src/workspace.ts";
+
+class TestWorker extends Worker {
+  // テスト用にgetRelativePathをpublicにする
+  public testGetRelativePath(filePath: string): string {
+    // @ts-ignore - private メソッドにアクセス
+    return this.getRelativePath(filePath);
+  }
+
+  // テスト用にworktreePathを設定できるようにする
+  public setWorktreePathForTest(path: string | null): void {
+    // @ts-ignore - private プロパティにアクセス
+    this.worktreePath = path;
+  }
+}
+
+Deno.test("Worker.getRelativePath - worktreePathが設定されている場合", async () => {
+  const tempDir = await Deno.makeTempDir();
+  try {
+    const workspaceManager = new WorkspaceManager(tempDir);
+    const worker = new TestWorker("test-worker", workspaceManager);
+
+    // worktreePathを設定
+    const worktreePath = "/Users/test/workspace/repositories/org/repo";
+    worker.setWorktreePathForTest(worktreePath);
+
+    // worktreePath内のファイル
+    assertEquals(
+      worker.testGetRelativePath(`${worktreePath}/src/main.ts`),
+      "src/main.ts",
+    );
+
+    // worktreePath外のファイル
+    assertEquals(
+      worker.testGetRelativePath("/some/other/path/file.ts"),
+      "/some/other/path/file.ts",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("Worker.getRelativePath - リポジトリパターンの場合", async () => {
+  const tempDir = await Deno.makeTempDir();
+  try {
+    const workspaceManager = new WorkspaceManager(tempDir);
+    const worker = new TestWorker("test-worker", workspaceManager);
+
+    // worktreePathが未設定
+    worker.setWorktreePathForTest(null);
+
+    // repositories ディレクトリ内のファイル
+    assertEquals(
+      worker.testGetRelativePath(
+        "/work/repositories/myorg/myrepo/src/index.ts",
+      ),
+      "src/index.ts",
+    );
+
+    // 別のリポジトリ
+    assertEquals(
+      worker.testGetRelativePath("/var/data/repositories/org2/repo2/README.md"),
+      "README.md",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("Worker.getRelativePath - threadsパターンの場合", async () => {
+  const tempDir = await Deno.makeTempDir();
+  try {
+    const workspaceManager = new WorkspaceManager(tempDir);
+    const worker = new TestWorker("test-worker", workspaceManager);
+
+    // worktreePathが未設定
+    worker.setWorktreePathForTest(null);
+
+    // threads ディレクトリ内のworktree
+    assertEquals(
+      worker.testGetRelativePath("/work/threads/thread123/worktree/src/app.ts"),
+      "src/app.ts",
+    );
+
+    // 別のスレッド
+    assertEquals(
+      worker.testGetRelativePath(
+        "/data/threads/thread456/worktree/package.json",
+      ),
+      "package.json",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("Worker.getRelativePath - 特殊なケース", async () => {
+  const tempDir = await Deno.makeTempDir();
+  try {
+    const workspaceManager = new WorkspaceManager(tempDir);
+    const worker = new TestWorker("test-worker", workspaceManager);
+
+    // 空文字列
+    assertEquals(worker.testGetRelativePath(""), "");
+
+    // パターンにマッチしない通常のパス
+    assertEquals(
+      worker.testGetRelativePath("/usr/local/bin/some-file"),
+      "/usr/local/bin/some-file",
+    );
+
+    // worktreePathがルートディレクトリ終端のスラッシュあり
+    worker.setWorktreePathForTest("/work/repo/");
+    assertEquals(
+      worker.testGetRelativePath("/work/repo/file.ts"),
+      "file.ts",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("Worker.getRelativePath - Discord表示時の実際の使用", async () => {
+  const tempDir = await Deno.makeTempDir();
+  try {
+    const workspaceManager = new WorkspaceManager(tempDir);
+    const worker = new TestWorker("test-worker", workspaceManager);
+
+    // 実際のワークツリーパス例
+    const worktreePath =
+      "/Users/to-hutohu/workspace/claude-code-repos/worktrees/1234567890";
+    worker.setWorktreePathForTest(worktreePath);
+
+    // Read ツールの場合
+    const filePath = `${worktreePath}/src/main.ts`;
+    assertEquals(worker.testGetRelativePath(filePath), "src/main.ts");
+
+    // ネストしたディレクトリ
+    const nestedPath = `${worktreePath}/src/components/Button/index.tsx`;
+    assertEquals(
+      worker.testGetRelativePath(nestedPath),
+      "src/components/Button/index.tsx",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Discord投稿でツール実行時に表示されるファイルパスを、フルパスから作業ディレクトリからの相対パスに変更しました
- これによりセキュリティとプライバシーが向上し、表示も簡潔になります

## 変更内容
- `Worker.getRelativePath()`メソッドを追加
  - worktreePathが設定されている場合はそれを基準に相対パス化
  - repositoriesパターン（`/repositories/org/repo/`）に対応
  - threadsパターン（`/threads/thread-id/worktree/`）に対応
- 以下のツールの表示を修正：
  - Read（ファイル読み込み）
  - Write（ファイル書き込み）
  - Edit（ファイル編集）
  - MultiEdit（ファイル一括編集）
  - LS（ディレクトリ一覧）
  - NotebookRead（ノートブック読み込み）
  - NotebookEdit（ノートブック編集）

## Test plan
- [x] 相対パス変換のテストケースを追加（test/worker-relative-path.test.ts）
- [x] 既存のテストが全て成功することを確認
- [x] lint、typecheckが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - File and directory paths in tool descriptions are now displayed as relative paths, making them clearer and easier to read.
- **Tests**
  - Added comprehensive tests to verify correct extraction of relative paths in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->