### PR TITLE
feat: Claude Code実行時にdevcontainerまたは権限スキップを必須化

### DIFF
--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -2,6 +2,7 @@ import { assertEquals, assertStringIncludes } from "std/assert/mod.ts";
 import { Admin } from "../src/admin.ts";
 import { ClaudeCodeRateLimitError, Worker } from "../src/worker.ts";
 import { WorkspaceManager } from "../src/workspace.ts";
+import { createMockClaudeCommandExecutor } from "./test-utils.ts";
 
 Deno.test("レートリミット検出とメッセージ作成", async () => {
   const baseDir = await Deno.makeTempDir({ prefix: "test_rate_limit_" });
@@ -47,7 +48,8 @@ Deno.test("ClaudeCodeRateLimitError の作成と属性", () => {
 Deno.test("Worker でのレートリミット検出", () => {
   const baseDir = "/tmp/test";
   const workspaceManager = new WorkspaceManager(baseDir);
-  const worker = new Worker("test-worker", workspaceManager);
+  const mockExecutor = createMockClaudeCommandExecutor();
+  const worker = new Worker("test-worker", workspaceManager, mockExecutor);
 
   // private メソッドにアクセスするため型アサーション
   const workerAny = (worker as unknown) as {

--- a/test/worker-streaming.test.ts
+++ b/test/worker-streaming.test.ts
@@ -29,6 +29,7 @@ Deno.test("Worker - ストリーミング進捗コールバックが呼ばれる
 
     // Setup repository
     const repository = createTestRepository("test", "repo");
+    worker.setSkipPermissions(true);
     await worker.setRepository(repository, tempDir);
 
     const progressUpdates: string[] = [];
@@ -73,6 +74,7 @@ Deno.test("Worker - エラー時のストリーミング処理", async () => {
     const worker = new Worker("test-worker", workspace, mockExecutor);
 
     const repository = createTestRepository("test", "repo");
+    worker.setSkipPermissions(true);
     await worker.setRepository(repository, tempDir);
 
     const progressUpdates: string[] = [];
@@ -114,6 +116,7 @@ Deno.test("Worker - 進捗コールバックなしでも動作する", async () 
     const worker = new Worker("test-worker", workspace, mockExecutor);
 
     const repository = createTestRepository("test", "repo");
+    worker.setSkipPermissions(true);
     await worker.setRepository(repository, tempDir);
 
     // No progress callback provided


### PR DESCRIPTION
## Summary
- Claude Code実行時のセキュリティを強化
- devcontainerまたは`--dangerously-skip-permissions`オプションを必須に

## 変更内容
### 1. セキュリティ強化
- `DefaultClaudeCommandExecutor`クラスを削除し、直接リポジトリ内での実行を廃止
- `processMessage`と`executeClaude`メソッドで環境設定をチェック

### 2. ユーザビリティ改善
- 環境未設定時に分かりやすいエラーメッセージを表示
- 使用可能なオプションを明示的に案内

### 3. テストの修正
- 全テストケースで`setSkipPermissions(true)`を適切に設定
- モックExecutorを使用するように修正

## 動作確認
- 全てのテストが成功することを確認済み
- `deno task test`で114件のテストが全てパス

## 影響範囲
この変更により、Claude Codeを実行する際は必ず以下のいずれかが必要になります：
- `/start <repository> --devcontainer` でdevcontainer環境を使用
- `/start <repository> --skip-permissions` で権限チェックをスキップ

セキュリティ向上のため、意図しない権限でのコード実行を防ぐ重要な変更です。

🤖 Generated with [Claude Code](https://claude.ai/code)