### PR TITLE
refactor: Deno組み込みの.env読み込み機能に移行

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -4,8 +4,8 @@
     "fmt": "deno fmt",
     "check": "deno check **/*.ts",
     "lint": "deno lint",
-    "dev": "deno run --allow-read --allow-write --allow-env --allow-net --allow-run --watch src/main.ts",
-    "start": "deno run --allow-read --allow-write --allow-env --allow-net --allow-run src/main.ts",
+    "dev": "deno run --env-file --allow-read --allow-write --allow-env --allow-net --allow-run --watch src/main.ts",
+    "start": "deno run --env-file --allow-read --allow-write --allow-env --allow-net --allow-run src/main.ts",
     "setup-hooks": "sh setup-hooks.sh",
     "pre-commit": "deno fmt --check && deno lint && deno check src/main.ts && deno test --allow-read --allow-write --allow-env --allow-run"
   },

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,15 +1,10 @@
-import { load } from "std/dotenv/mod.ts";
-
 export interface Env {
   DISCORD_TOKEN: string;
   WORK_BASE_DIR: string;
   VERBOSE?: boolean;
 }
 
-export async function getEnv(): Promise<Env> {
-  // .envファイルを読み込み
-  await load({ export: true });
-
+export function getEnv(): Env {
   const token = Deno.env.get("DISCORD_TOKEN");
   const workBaseDir = Deno.env.get("WORK_BASE_DIR");
   const verbose = Deno.env.get("VERBOSE") === "true";

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,7 +43,7 @@ if (!systemCheck.success) {
 
 console.log("\n✅ システム要件チェック完了\n");
 
-const env = await getEnv();
+const env = getEnv();
 const workspaceManager = new WorkspaceManager(env.WORK_BASE_DIR);
 await workspaceManager.initialize();
 const admin = new Admin(workspaceManager, env.VERBOSE);

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -17,6 +17,7 @@ fi
 # --watchオプションでファイル変更を監視
 # --allow-*オプションで必要な権限を付与
 exec deno run \
+    --env-file \
     --watch \
     --allow-read \
     --allow-write \

--- a/start-prod.sh
+++ b/start-prod.sh
@@ -14,6 +14,7 @@ fi
 
 # 通常モードで起動（HMRなし）
 exec deno run \
+    --env-file \
     --allow-read \
     --allow-write \
     --allow-env \


### PR DESCRIPTION
- std/dotenvモジュールの使用を廃止
- Denoの--env-fileフラグを使用した.env読み込みに変更
- getEnv()関数を同期関数に変更
- 起動スクリプトとタスクに--env-fileフラグを追加

これにより外部依存を減らし、Denoのネイティブ機能を活用するように改善

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 環境変数ファイル（.env）の自動読み込みに対応しました。

- **改善**
  - 起動スクリプトと設定で環境変数の扱いが簡素化され、より直感的に利用できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->