### PR TITLE
feat: 権限チェックを常にスキップするように変更

### DIFF
--- a/src/admin.ts
+++ b/src/admin.ts
@@ -981,7 +981,6 @@ export class Admin implements IAdmin {
       // devcontainer設定情報を保存（ファイル未存在）
       const config = {
         useDevcontainer: false,
-        skipPermissions: false,
         hasDevcontainerFile: false,
         hasAnthropicsFeature: false,
         isStarted: false,
@@ -1029,7 +1028,6 @@ export class Admin implements IAdmin {
       // devcontainer設定情報を保存（CLI未インストール）
       const config = {
         useDevcontainer: false,
-        skipPermissions: false,
         hasDevcontainerFile: true,
         hasAnthropicsFeature: devcontainerInfo.hasAnthropicsFeature ?? false,
         isStarted: false,
@@ -1080,7 +1078,6 @@ export class Admin implements IAdmin {
     // devcontainer設定情報を保存（ファイル存在状況とfeature情報のみ）
     const config = {
       useDevcontainer: false, // まだ選択されていない
-      skipPermissions: false,
       hasDevcontainerFile: true,
       hasAnthropicsFeature: devcontainerInfo.hasAnthropicsFeature ?? false,
       isStarted: false,
@@ -1218,7 +1215,6 @@ export class Admin implements IAdmin {
     const existingConfig = await this.getDevcontainerConfig(threadId);
     const config = {
       useDevcontainer: true,
-      skipPermissions: true, // 常にtrue
       hasDevcontainerFile: existingConfig?.hasDevcontainerFile ?? false,
       hasAnthropicsFeature: existingConfig?.hasAnthropicsFeature ?? false,
       containerId: existingConfig?.containerId,
@@ -1246,7 +1242,6 @@ export class Admin implements IAdmin {
     const existingConfig = await this.getDevcontainerConfig(threadId);
     const config = {
       useDevcontainer: false,
-      skipPermissions: true, // 常にtrue
       hasDevcontainerFile: existingConfig?.hasDevcontainerFile ?? false,
       hasAnthropicsFeature: existingConfig?.hasAnthropicsFeature ?? false,
       containerId: existingConfig?.containerId,
@@ -1264,7 +1259,6 @@ export class Admin implements IAdmin {
     threadId: string,
     config: {
       useDevcontainer: boolean;
-      skipPermissions: boolean;
       hasDevcontainerFile: boolean;
       hasAnthropicsFeature: boolean;
       containerId?: string;
@@ -1286,7 +1280,6 @@ export class Admin implements IAdmin {
   async getDevcontainerConfig(threadId: string): Promise<
     {
       useDevcontainer: boolean;
-      skipPermissions: boolean;
       hasDevcontainerFile: boolean;
       hasAnthropicsFeature: boolean;
       containerId?: string;

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -21,7 +21,6 @@ export interface ThreadInfo {
   status: "active" | "inactive" | "archived";
   devcontainerConfig: {
     useDevcontainer: boolean;
-    skipPermissions: boolean;
     hasDevcontainerFile: boolean;
     hasAnthropicsFeature: boolean;
     containerId?: string;

--- a/test/admin.test.ts
+++ b/test/admin.test.ts
@@ -471,7 +471,6 @@ Deno.test("Admin - devcontainer設定情報を正しく保存・取得できる"
   // devcontainer設定を保存
   const config = {
     useDevcontainer: true,
-    skipPermissions: true, // 常にtrue
     hasDevcontainerFile: true,
     hasAnthropicsFeature: true,
     containerId: "container123",
@@ -484,7 +483,6 @@ Deno.test("Admin - devcontainer設定情報を正しく保存・取得できる"
   const retrievedConfig = await admin.getDevcontainerConfig(threadId);
 
   assertEquals(retrievedConfig?.useDevcontainer, true);
-  assertEquals(retrievedConfig?.skipPermissions, true);
   assertEquals(retrievedConfig?.hasDevcontainerFile, true);
   assertEquals(retrievedConfig?.hasAnthropicsFeature, true);
   assertEquals(retrievedConfig?.containerId, "container123");
@@ -502,7 +500,6 @@ Deno.test("Admin - ThreadInfoにdevcontainer設定が永続化される", async 
   // devcontainer設定を保存
   const config = {
     useDevcontainer: false,
-    skipPermissions: true,
     hasDevcontainerFile: false,
     hasAnthropicsFeature: false,
     isStarted: false,
@@ -514,7 +511,6 @@ Deno.test("Admin - ThreadInfoにdevcontainer設定が永続化される", async 
   const threadInfo = await workspace.loadThreadInfo(threadId);
 
   assertEquals(threadInfo?.devcontainerConfig?.useDevcontainer, false);
-  assertEquals(threadInfo?.devcontainerConfig?.skipPermissions, true);
   assertEquals(threadInfo?.devcontainerConfig?.hasDevcontainerFile, false);
   assertEquals(threadInfo?.devcontainerConfig?.hasAnthropicsFeature, false);
   assertEquals(threadInfo?.devcontainerConfig?.isStarted, false);
@@ -542,7 +538,6 @@ Deno.test("Admin - アクティブなスレッドを復旧できる", async () =
   // devcontainer設定を保存
   const config = {
     useDevcontainer: true,
-    skipPermissions: true, // 常にtrue
     hasDevcontainerFile: true,
     hasAnthropicsFeature: true,
     containerId: "test-container-456",
@@ -570,7 +565,6 @@ Deno.test("Admin - アクティブなスレッドを復旧できる", async () =
   // devcontainer設定も復旧されている
   const restoredConfig = await admin2.getDevcontainerConfig(threadId);
   assertEquals(restoredConfig?.useDevcontainer, true);
-  assertEquals(restoredConfig?.skipPermissions, true);
   assertEquals(restoredConfig?.hasDevcontainerFile, true);
   assertEquals(restoredConfig?.hasAnthropicsFeature, true);
   assertEquals(restoredConfig?.containerId, "test-container-456");
@@ -618,7 +612,6 @@ Deno.test("Admin - 復旧時のエラーハンドリング", async () => {
     status: "active" as const,
     devcontainerConfig: {
       useDevcontainer: false,
-      skipPermissions: true, // 常にtrue
       hasDevcontainerFile: false,
       hasAnthropicsFeature: false,
       isStarted: false,
@@ -712,7 +705,6 @@ Deno.test("Admin - worktreeが存在するスレッドは正常に復旧され�
     status: "active" as const,
     devcontainerConfig: {
       useDevcontainer: false,
-      skipPermissions: true, // 常にtrue
       hasDevcontainerFile: false,
       hasAnthropicsFeature: false,
       isStarted: false,
@@ -755,7 +747,6 @@ Deno.test("Admin - devcontainer設定がWorkerに正しく復旧される", asyn
     status: "active" as const,
     devcontainerConfig: {
       useDevcontainer: true,
-      skipPermissions: true,
       hasDevcontainerFile: true,
       hasAnthropicsFeature: true,
       containerId: "restored-container-123",
@@ -781,7 +772,6 @@ Deno.test("Admin - devcontainer設定がWorkerに正しく復旧される", asyn
   // devcontainer設定がAdminからも取得できることを確認
   const restoredConfig = await admin.getDevcontainerConfig(threadId);
   assertEquals(restoredConfig?.useDevcontainer, true);
-  assertEquals(restoredConfig?.skipPermissions, true);
   assertEquals(restoredConfig?.hasDevcontainerFile, true);
   assertEquals(restoredConfig?.hasAnthropicsFeature, true);
   assertEquals(restoredConfig?.containerId, "restored-container-123");

--- a/test/admin.test.ts
+++ b/test/admin.test.ts
@@ -335,7 +335,6 @@ Deno.test("Admin - 初期メッセージにdevcontainer流れの説明が含ま�
     initialMessage.content.includes("devcontainer利用の可否選択"),
     true,
   );
-  assertEquals(initialMessage.content.includes("権限設定の選択"), true);
   assertEquals(initialMessage.content.includes("Claude実行環境の準備"), true);
 });
 
@@ -472,7 +471,7 @@ Deno.test("Admin - devcontainer設定情報を正しく保存・取得できる"
   // devcontainer設定を保存
   const config = {
     useDevcontainer: true,
-    skipPermissions: false,
+    skipPermissions: true, // 常にtrue
     hasDevcontainerFile: true,
     hasAnthropicsFeature: true,
     containerId: "container123",
@@ -485,7 +484,7 @@ Deno.test("Admin - devcontainer設定情報を正しく保存・取得できる"
   const retrievedConfig = await admin.getDevcontainerConfig(threadId);
 
   assertEquals(retrievedConfig?.useDevcontainer, true);
-  assertEquals(retrievedConfig?.skipPermissions, false);
+  assertEquals(retrievedConfig?.skipPermissions, true);
   assertEquals(retrievedConfig?.hasDevcontainerFile, true);
   assertEquals(retrievedConfig?.hasAnthropicsFeature, true);
   assertEquals(retrievedConfig?.containerId, "container123");
@@ -543,7 +542,7 @@ Deno.test("Admin - アクティブなスレッドを復旧できる", async () =
   // devcontainer設定を保存
   const config = {
     useDevcontainer: true,
-    skipPermissions: false,
+    skipPermissions: true, // 常にtrue
     hasDevcontainerFile: true,
     hasAnthropicsFeature: true,
     containerId: "test-container-456",
@@ -571,7 +570,7 @@ Deno.test("Admin - アクティブなスレッドを復旧できる", async () =
   // devcontainer設定も復旧されている
   const restoredConfig = await admin2.getDevcontainerConfig(threadId);
   assertEquals(restoredConfig?.useDevcontainer, true);
-  assertEquals(restoredConfig?.skipPermissions, false);
+  assertEquals(restoredConfig?.skipPermissions, true);
   assertEquals(restoredConfig?.hasDevcontainerFile, true);
   assertEquals(restoredConfig?.hasAnthropicsFeature, true);
   assertEquals(restoredConfig?.containerId, "test-container-456");
@@ -619,7 +618,7 @@ Deno.test("Admin - 復旧時のエラーハンドリング", async () => {
     status: "active" as const,
     devcontainerConfig: {
       useDevcontainer: false,
-      skipPermissions: false,
+      skipPermissions: true, // 常にtrue
       hasDevcontainerFile: false,
       hasAnthropicsFeature: false,
       isStarted: false,
@@ -713,7 +712,7 @@ Deno.test("Admin - worktreeが存在するスレッドは正常に復旧され�
     status: "active" as const,
     devcontainerConfig: {
       useDevcontainer: false,
-      skipPermissions: false,
+      skipPermissions: true, // 常にtrue
       hasDevcontainerFile: false,
       hasAnthropicsFeature: false,
       isStarted: false,
@@ -777,7 +776,6 @@ Deno.test("Admin - devcontainer設定がWorkerに正しく復旧される", asyn
   // Worker内のdevcontainer設定が復旧されていることを確認
   if (worker) {
     assertEquals(worker.isUsingDevcontainer(), true);
-    assertEquals(worker.isSkipPermissions(), true);
   }
 
   // devcontainer設定がAdminからも取得できることを確認
@@ -823,7 +821,6 @@ Deno.test("Admin - devcontainer設定未設定スレッドの復旧", async () =
   // Worker内のdevcontainer設定がデフォルト値であることを確認
   if (worker) {
     assertEquals(worker.isUsingDevcontainer(), false);
-    assertEquals(worker.isSkipPermissions(), false);
   }
 
   // devcontainer設定がnullであることを確認

--- a/test/persistence_integration.test.ts
+++ b/test/persistence_integration.test.ts
@@ -39,7 +39,6 @@ Deno.test("永続化統合テスト - スレッド作成から復旧まで完全
     // devcontainer設定を保存
     const devcontainerConfig = {
       useDevcontainer: true,
-      skipPermissions: false,
       hasDevcontainerFile: true,
       hasAnthropicsFeature: true,
       containerId: "test-container-integration",
@@ -64,7 +63,6 @@ Deno.test("永続化統合テスト - スレッド作成から復旧まで完全
     // devcontainer設定が正しく復旧されている
     const restoredConfig = await admin2.getDevcontainerConfig(threadId);
     assertEquals(restoredConfig?.useDevcontainer, true);
-    assertEquals(restoredConfig?.skipPermissions, false);
     assertEquals(restoredConfig?.hasDevcontainerFile, true);
     assertEquals(restoredConfig?.hasAnthropicsFeature, true);
     assertEquals(restoredConfig?.containerId, "test-container-integration");
@@ -107,7 +105,6 @@ Deno.test("永続化統合テスト - 複数スレッドの管理と復旧", asy
       // 各スレッドに異なるdevcontainer設定
       const config = {
         useDevcontainer: threadId === "thread-1",
-        skipPermissions: threadId === "thread-2",
         hasDevcontainerFile: threadId !== "thread-3",
         hasAnthropicsFeature: threadId === "thread-1",
         containerId: threadId === "thread-1"
@@ -158,7 +155,6 @@ Deno.test("永続化統合テスト - セッションログとワークスペー
     // devcontainer設定を保存
     const config = {
       useDevcontainer: false,
-      skipPermissions: true,
       hasDevcontainerFile: false,
       hasAnthropicsFeature: false,
       isStarted: false,
@@ -170,7 +166,6 @@ Deno.test("永続化統合テスト - セッションログとワークスペー
     const targetThread = allThreadInfos.find((t) => t.threadId === threadId);
     assertExists(targetThread);
     assertEquals(targetThread.status, "active");
-    assertEquals(targetThread.devcontainerConfig?.skipPermissions, true);
 
     // Phase 3: 再起動と復旧
     const admin2 = new Admin(workspace);
@@ -178,7 +173,6 @@ Deno.test("永続化統合テスト - セッションログとワークスペー
 
     // 復旧後の設定確認
     const restoredConfig = await admin2.getDevcontainerConfig(threadId);
-    assertEquals(restoredConfig?.skipPermissions, true);
     assertEquals(restoredConfig?.useDevcontainer, false);
 
     // Phase 4: 設定変更と再保存
@@ -198,7 +192,6 @@ Deno.test("永続化統合テスト - セッションログとワークスペー
     assertEquals(finalConfig?.useDevcontainer, true);
     assertEquals(finalConfig?.containerId, "new-container-123");
     assertEquals(finalConfig?.isStarted, true);
-    assertEquals(finalConfig?.skipPermissions, true); // 元の設定も保持
   } finally {
     await cleanup();
   }
@@ -216,7 +209,6 @@ Deno.test("永続化統合テスト - エラー耐性と部分復旧", async () 
     await admin1.createWorker(goodThreadId);
     await admin1.saveDevcontainerConfig(goodThreadId, {
       useDevcontainer: false,
-      skipPermissions: false,
       hasDevcontainerFile: true,
       hasAnthropicsFeature: true,
       isStarted: false,
@@ -234,7 +226,6 @@ Deno.test("永続化統合テスト - エラー耐性と部分復旧", async () 
       status: "active" as const,
       devcontainerConfig: {
         useDevcontainer: true,
-        skipPermissions: false,
         hasDevcontainerFile: true,
         hasAnthropicsFeature: false,
         containerId: "invalid-container",

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -274,7 +274,6 @@ export function createErrorMockClaudeCommandExecutor(
 export function createTestDevcontainerConfig(
   options: {
     useDevcontainer?: boolean;
-    skipPermissions?: boolean;
     hasDevcontainerFile?: boolean;
     hasAnthropicsFeature?: boolean;
     containerId?: string;
@@ -283,7 +282,6 @@ export function createTestDevcontainerConfig(
 ) {
   return {
     useDevcontainer: options.useDevcontainer ?? false,
-    skipPermissions: options.skipPermissions ?? false,
     hasDevcontainerFile: options.hasDevcontainerFile ?? false,
     hasAnthropicsFeature: options.hasAnthropicsFeature ?? false,
     containerId: options.containerId,

--- a/test/worker-streaming.test.ts
+++ b/test/worker-streaming.test.ts
@@ -30,9 +30,8 @@ Deno.test("Worker - ストリーミング進捗コールバックが呼ばれる
     // Setup repository
     const repository = createTestRepository("test", "repo");
 
-    // 両方の設定を完了させる
+    // devcontainer設定を完了させる
     worker.setUseDevcontainer(false); // ホスト環境を選択
-    worker.setSkipPermissions(true); // 権限チェックをスキップ
 
     await worker.setRepository(repository, tempDir);
 
@@ -79,9 +78,8 @@ Deno.test("Worker - エラー時のストリーミング処理", async () => {
 
     const repository = createTestRepository("test", "repo");
 
-    // 両方の設定を完了させる
+    // devcontainer設定を完了させる
     worker.setUseDevcontainer(false); // ホスト環境を選択
-    worker.setSkipPermissions(true); // 権限チェックをスキップ
 
     await worker.setRepository(repository, tempDir);
 
@@ -125,9 +123,8 @@ Deno.test("Worker - 進捗コールバックなしでも動作する", async () 
 
     const repository = createTestRepository("test", "repo");
 
-    // 両方の設定を完了させる
+    // devcontainer設定を完了させる
     worker.setUseDevcontainer(false); // ホスト環境を選択
-    worker.setSkipPermissions(true); // 権限チェックをスキップ
 
     await worker.setRepository(repository, tempDir);
 

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -61,9 +61,8 @@ Deno.test("Worker - リポジトリ情報を設定・取得できる", async () 
     const repository = createTestRepository("octocat", "Hello-World");
     const repoPath = "/path/to/repo";
 
-    // 両方の設定を完了させる
+    // devcontainer設定を完了させる
     worker.setUseDevcontainer(false); // ホスト環境を選択
-    worker.setSkipPermissions(true); // 権限チェックをスキップ
 
     await worker.setRepository(repository, repoPath);
     const retrievedRepo = worker.getRepository();
@@ -92,7 +91,6 @@ Deno.test("Worker - 設定未完了時の定型メッセージ", async () => {
     // 設定を促すメッセージが返されることを確認
     assertEquals(reply.includes("Claude Code実行環境の設定が必要です"), true);
     assertEquals(reply.includes("/config devcontainer"), true);
-    assertEquals(reply.includes("/config permissions"), true);
   } finally {
     // クリーンアップ
   }
@@ -107,9 +105,8 @@ Deno.test("Worker - リポジトリ設定後のメッセージ処理", async () 
     const worker = await createTestWorker("test-worker", workspace, executor);
     const repository = createTestRepository("octocat", "Hello-World");
 
-    // 両方の設定を完了させる
+    // devcontainer設定を完了させる
     worker.setUseDevcontainer(false); // ホスト環境を選択
-    worker.setSkipPermissions(false); // 通常の権限チェックを使用
 
     await worker.setRepository(repository, "/test/repo");
 
@@ -208,9 +205,8 @@ Deno.test("Worker - Claude Codeの実際の出力が行ごとに送信される"
       mockExecutor,
     );
 
-    // 両方の設定を完了させる
+    // devcontainer設定を完了させる
     worker.setUseDevcontainer(false); // ホスト環境を選択
-    worker.setSkipPermissions(true); // 権限チェックをスキップ
 
     await worker.setRepository(repository, repoPath);
 
@@ -243,9 +239,8 @@ Deno.test("Worker - エラーメッセージも正しく出力される", async 
       errorExecutor,
     );
 
-    // 両方の設定を完了させる
+    // devcontainer設定を完了させる
     worker.setUseDevcontainer(false); // ホスト環境を選択
-    worker.setSkipPermissions(true); // 権限チェックをスキップ
 
     await worker.setRepository(repository, repoPath);
 

--- a/test/workspace.test.ts
+++ b/test/workspace.test.ts
@@ -153,7 +153,6 @@ Deno.test("WorkspaceManager - ThreadInfoにdevcontainerConfigが含まれる", a
     const threadId = "test-thread-devcontainer";
     const devcontainerConfig = {
       useDevcontainer: true,
-      skipPermissions: false,
       hasDevcontainerFile: true,
       hasAnthropicsFeature: true,
       containerId: "test-container-123",
@@ -175,7 +174,6 @@ Deno.test("WorkspaceManager - ThreadInfoにdevcontainerConfigが含まれる", a
     const loaded = await workspace.loadThreadInfo(threadId);
 
     assertEquals(loaded?.devcontainerConfig?.useDevcontainer, true);
-    assertEquals(loaded?.devcontainerConfig?.skipPermissions, false);
     assertEquals(loaded?.devcontainerConfig?.hasDevcontainerFile, true);
     assertEquals(loaded?.devcontainerConfig?.hasAnthropicsFeature, true);
     assertEquals(loaded?.devcontainerConfig?.containerId, "test-container-123");


### PR DESCRIPTION
--dangerously-skip-permissions フラグをデフォルトで常に使用するよう修正。 権限設定の選択フローを削除し、devcontainer環境の選択のみに簡略化。

変更内容:
- executeClaudeメソッドで常に--dangerously-skip-permissionsを追加
- 権限設定関連のフィールド・メソッドを削除
- 権限設定のUIフローを削除
- /configコマンドの処理を実装し、devcontainer設定のみ受け付ける
- テストの修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能の削除**
  - 権限スキップ設定に関するUIや選択フローを完全に削除し、常に権限チェックをスキップする仕様に統一しました。

- **仕様変更**
  - devcontainer構成の保存時に`skipPermissions`が除外されるようになりました。
  - 初期メッセージや設定プロンプトから権限選択の手順を削除しました。
  - `/config devcontainer` コマンドでdevcontainer実行の有効/無効を切り替え可能になりました。

- **バグ修正**
  - テストコードを新仕様に合わせて修正し、権限スキップ設定に依存しない内容に統一しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->