### PR TITLE
devcontainerでGH_TOKEN環境変数を受け渡すように設定

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,9 @@
   },
   "forwardPorts": [],
   "remoteUser": "codespace",
+  "containerEnv": {
+    "GH_TOKEN": "${localEnv:GH_TOKEN}"
+  },
   "mounts": [
     "source=${localEnv:HOME}/.gitconfig,target=/home/codespace/.gitconfig,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.ssh,target=/home/codespace/.ssh,type=bind,consistency=cached",


### PR DESCRIPTION
## 概要
`devcontainer up`で指定されたGH_TOKEN環境変数がコンテナ内で利用できるよう、devcontainer.jsonに設定を追加しました。

## 変更内容
- `.devcontainer/devcontainer.json`に`containerEnv`セクションを追加
- `GH_TOKEN`をローカル環境変数からコンテナ環境へマッピング

## 背景
devcontainer起動時に`GH_TOKEN`を環境変数として渡しても、コンテナ内で参照できない問題がありました。
VS Codeのドキュメント（https://code.visualstudio.com/remote/advancedcontainers/environment-variables）に従い、
`containerEnv`を使用してローカル環境変数をコンテナ内に渡すよう設定しました。

## 影響
- GitHub CLIがプライベートリポジトリへのアクセス時に認証トークンを正しく利用できるようになります
- `devcontainer up`実行時に`GH_TOKEN`環境変数が設定されていれば、自動的にコンテナ内で利用可能になります

## テスト方法
1. `GH_TOKEN=your_token devcontainer up`でコンテナを起動
2. コンテナ内で`echo $GH_TOKEN`を実行し、トークンが設定されていることを確認
3. `gh repo list`などのGitHub CLIコマンドが認証エラーなく実行できることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - コンテナ環境で `GH_TOKEN` 環境変数が利用できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->