### PR TITLE
レートリミット時の自動メッセージキュー処理を実装

### DIFF
--- a/src/admin.ts
+++ b/src/admin.ts
@@ -350,7 +350,7 @@ export class Admin implements IAdmin {
   /**
    * レートリミットメッセージを作成する（ボタンなし）
    */
-  createRateLimitMessage(threadId: string, timestamp: number): string {
+  createRateLimitMessage(_threadId: string, timestamp: number): string {
     const resumeTime = new Date(timestamp * 1000 + 5 * 60 * 1000);
     const resumeTimeStr = resumeTime.toLocaleString("ja-JP", {
       timeZone: "Asia/Tokyo",
@@ -496,13 +496,15 @@ export class Admin implements IAdmin {
         authorId,
       };
       await this.workspaceManager.addMessageToQueue(threadId, queuedMessage);
-      
+
       this.logVerbose("メッセージをキューに追加", {
         threadId,
         messageId,
-        queueLength: (await this.workspaceManager.loadMessageQueue(threadId))?.messages.length || 0,
+        queueLength:
+          (await this.workspaceManager.loadMessageQueue(threadId))?.messages
+            .length || 0,
       });
-      
+
       return "レートリミット中です。このメッセージは制限解除後に自動的に処理されます。";
     }
 
@@ -740,19 +742,20 @@ export class Admin implements IAdmin {
       await this.workspaceManager.saveThreadInfo(threadInfo);
 
       // キューに溜まったメッセージを処理
-      const queuedMessages = await this.workspaceManager.getAndClearMessageQueue(threadId);
-      
+      const queuedMessages = await this.workspaceManager
+        .getAndClearMessageQueue(threadId);
+
       if (queuedMessages.length > 0) {
         this.logVerbose("キューからメッセージを処理", {
           threadId,
           messageCount: queuedMessages.length,
         });
-        
+
         // 最初のメッセージを処理
         if (this.onAutoResumeMessage) {
           const firstMessage = queuedMessages[0];
           await this.onAutoResumeMessage(threadId, firstMessage.content);
-          
+
           // 監査ログに記録
           await this.logAuditEntry(threadId, "queued_message_processed", {
             messageId: firstMessage.messageId,

--- a/src/admin_rate_limit_test.ts
+++ b/src/admin_rate_limit_test.ts
@@ -1,0 +1,269 @@
+import {
+  assert,
+  assertEquals,
+  assertExists,
+} from "std/assert/mod.ts";
+import { join } from "std/path/mod.ts";
+import { Admin } from "./admin.ts";
+import { ClaudeCodeRateLimitError, IWorker } from "./worker.ts";
+import { QueuedMessage, WorkspaceManager } from "./workspace.ts";
+
+async function createTestDir(): Promise<string> {
+  const testDir = await Deno.makeTempDir({
+    prefix: "admin_rate_limit_test_",
+  });
+  return testDir;
+}
+
+// モックWorkerクラス
+class MockWorker implements IWorker {
+  private name: string;
+  private shouldThrowRateLimit = false;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  getName(): string {
+    return this.name;
+  }
+
+  getRepository() {
+    return null;
+  }
+
+  setRepository() {}
+
+  setWorktreePath() {}
+
+  setThreadId() {}
+
+  setSessionId() {}
+
+  setRateLimitBehavior(shouldThrow: boolean) {
+    this.shouldThrowRateLimit = shouldThrow;
+  }
+
+  async processMessage(
+    message: string,
+    _onProgress?: (content: string) => Promise<void>,
+    _onReaction?: (emoji: string) => Promise<void>,
+  ): Promise<string> {
+    if (this.shouldThrowRateLimit) {
+      throw new ClaudeCodeRateLimitError(Math.floor(Date.now() / 1000));
+    }
+    return `処理済み: ${message}`;
+  }
+
+  async terminateDevcontainer(): Promise<void> {}
+
+  async setDevcontainerChoice(): Promise<void> {}
+
+  async waitForDevcontainerChoice(): Promise<void> {}
+}
+
+Deno.test("Admin - レートリミット時のメッセージキュー追加", async () => {
+  const testDir = await createTestDir();
+  try {
+    const workspaceManager = new WorkspaceManager(testDir);
+    await workspaceManager.initialize();
+
+    const admin = new Admin(workspaceManager);
+    const threadId = "test-thread-rate-limit";
+
+    // スレッド情報を作成
+    await workspaceManager.saveThreadInfo({
+      threadId,
+      repositoryFullName: null,
+      repositoryLocalPath: null,
+      worktreePath: null,
+      createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
+      status: "active",
+      devcontainerConfig: null,
+      rateLimitTimestamp: Math.floor(Date.now() / 1000), // レートリミット中
+    });
+
+    // レートリミット中のメッセージ送信
+    const result = await admin.routeMessage(
+      threadId,
+      "テストメッセージ",
+      undefined,
+      undefined,
+      "msg-123",
+      "user-123"
+    );
+
+    assertEquals(result, "レートリミット中です。このメッセージは制限解除後に自動的に処理されます。");
+
+    // キューに追加されていることを確認
+    const queue = await workspaceManager.loadMessageQueue(threadId);
+    assertExists(queue);
+    assertEquals(queue!.messages.length, 1);
+    assertEquals(queue!.messages[0].messageId, "msg-123");
+    assertEquals(queue!.messages[0].content, "テストメッセージ");
+    assertEquals(queue!.messages[0].authorId, "user-123");
+  } finally {
+    await Deno.remove(testDir, { recursive: true });
+  }
+});
+
+Deno.test("Admin - レートリミットエラー時の自動タイマー設定", async () => {
+  const testDir = await createTestDir();
+  try {
+    const workspaceManager = new WorkspaceManager(testDir);
+    await workspaceManager.initialize();
+
+    const admin = new Admin(workspaceManager);
+    const threadId = "test-thread-auto-timer";
+
+    // モックWorkerを作成
+    const mockWorker = new MockWorker("test-worker");
+    mockWorker.setRateLimitBehavior(true);
+
+    // Workerを直接設定（プライベートプロパティへのアクセス）
+    (admin as any).workers.set(threadId, mockWorker);
+
+    // スレッド情報を作成
+    await workspaceManager.saveThreadInfo({
+      threadId,
+      repositoryFullName: null,
+      repositoryLocalPath: null,
+      worktreePath: null,
+      createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
+      status: "active",
+      devcontainerConfig: null,
+    });
+
+    // レートリミットエラーを発生させる
+    const result = await admin.routeMessage(threadId, "テスト");
+
+    // レートリミットメッセージが返されることを確認
+    assert(typeof result === "string");
+    assert(result.includes("Claude Codeのレートリミットに達しました"));
+
+    // スレッド情報が更新されていることを確認
+    const threadInfo = await workspaceManager.loadThreadInfo(threadId);
+    assertExists(threadInfo);
+    assertExists(threadInfo!.rateLimitTimestamp);
+    assertEquals(threadInfo!.autoResumeAfterRateLimit, true);
+
+    // タイマーが設定されていることを確認
+    const timers = (admin as any).autoResumeTimers as Map<string, number>;
+    assert(timers.has(threadId));
+  } finally {
+    await Deno.remove(testDir, { recursive: true });
+  }
+});
+
+Deno.test("Admin - 自動再開時のキュー処理", async () => {
+  const testDir = await createTestDir();
+  try {
+    const workspaceManager = new WorkspaceManager(testDir);
+    await workspaceManager.initialize();
+
+    const admin = new Admin(workspaceManager);
+    const threadId = "test-thread-auto-resume";
+
+    // キューにメッセージを追加
+    const queuedMessages: QueuedMessage[] = [
+      {
+        messageId: "msg-1",
+        content: "最初のメッセージ",
+        timestamp: Date.now(),
+        authorId: "user-1",
+      },
+      {
+        messageId: "msg-2",
+        content: "二番目のメッセージ",
+        timestamp: Date.now() + 1000,
+        authorId: "user-2",
+      },
+    ];
+
+    for (const msg of queuedMessages) {
+      await workspaceManager.addMessageToQueue(threadId, msg);
+    }
+
+    // スレッド情報を作成（自動再開有効）
+    await workspaceManager.saveThreadInfo({
+      threadId,
+      repositoryFullName: null,
+      repositoryLocalPath: null,
+      worktreePath: null,
+      createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
+      status: "active",
+      devcontainerConfig: null,
+      rateLimitTimestamp: Math.floor(Date.now() / 1000),
+      autoResumeAfterRateLimit: true,
+    });
+
+    // 自動再開コールバックを設定
+    let resumedThreadId: string | null = null;
+    let resumedMessage: string | null = null;
+    admin.setAutoResumeCallback(async (threadId, message) => {
+      resumedThreadId = threadId;
+      resumedMessage = message;
+    });
+
+    // executeAutoResumeを直接呼び出し（プライベートメソッドへのアクセス）
+    await (admin as any).executeAutoResume(threadId);
+
+    // コールバックが呼ばれたことを確認
+    assertEquals(resumedThreadId, threadId);
+    assertEquals(resumedMessage, "最初のメッセージ");
+
+    // キューがクリアされていることを確認
+    const queue = await workspaceManager.loadMessageQueue(threadId);
+    assertEquals(queue, null);
+
+    // スレッド情報がリセットされていることを確認
+    const threadInfo = await workspaceManager.loadThreadInfo(threadId);
+    assertExists(threadInfo);
+    assertEquals(threadInfo!.rateLimitTimestamp, undefined);
+    assertEquals(threadInfo!.autoResumeAfterRateLimit, undefined);
+  } finally {
+    await Deno.remove(testDir, { recursive: true });
+  }
+});
+
+Deno.test("Admin - キューが空の場合は「続けて」を送信", async () => {
+  const testDir = await createTestDir();
+  try {
+    const workspaceManager = new WorkspaceManager(testDir);
+    await workspaceManager.initialize();
+
+    const admin = new Admin(workspaceManager);
+    const threadId = "test-thread-empty-queue";
+
+    // スレッド情報を作成（自動再開有効、キューは空）
+    await workspaceManager.saveThreadInfo({
+      threadId,
+      repositoryFullName: null,
+      repositoryLocalPath: null,
+      worktreePath: null,
+      createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
+      status: "active",
+      devcontainerConfig: null,
+      rateLimitTimestamp: Math.floor(Date.now() / 1000),
+      autoResumeAfterRateLimit: true,
+    });
+
+    // 自動再開コールバックを設定
+    let resumedMessage: string | null = null;
+    admin.setAutoResumeCallback(async (_threadId, message) => {
+      resumedMessage = message;
+    });
+
+    // executeAutoResumeを直接呼び出し
+    await (admin as any).executeAutoResume(threadId);
+
+    // 「続けて」が送信されたことを確認
+    assertEquals(resumedMessage, "続けて");
+  } finally {
+    await Deno.remove(testDir, { recursive: true });
+  }
+});

--- a/src/admin_rate_limit_test.ts
+++ b/src/admin_rate_limit_test.ts
@@ -35,7 +35,10 @@ class MockWorker implements IWorker {
     return null;
   }
 
-  async setRepository(_repository: GitRepository, _localPath: string): Promise<void> {}
+  async setRepository(
+    _repository: GitRepository,
+    _localPath: string,
+  ): Promise<void> {}
 
   setWorktreePath() {}
 
@@ -163,7 +166,7 @@ Deno.test("Admin - レートリミットエラー時の自動タイマー設定"
     // タイマーが設定されていることを確認
     const testableAdmin2 = admin as unknown as TestableAdmin;
     assert(testableAdmin2.autoResumeTimers.has(threadId));
-    
+
     // タイマーをクリア
     const timerId = testableAdmin2.autoResumeTimers.get(threadId);
     if (timerId) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -779,6 +779,8 @@ client.on(Events.MessageCreate, async (message) => {
       message.content,
       onProgress,
       onReaction,
+      message.id,
+      message.author.id,
     );
 
     // 最終的な返信を送信

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -517,7 +517,7 @@ export class WorkspaceManager {
     }
 
     const messages = queue.messages;
-    
+
     // キューをクリア
     await this.deleteMessageQueue(threadId);
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -9,6 +9,7 @@ export interface WorkspaceConfig {
   auditDir: string;
   worktreesDir: string;
   patsDir: string;
+  queuedMessagesDir: string;
 }
 
 export interface ThreadInfo {
@@ -54,6 +55,18 @@ export interface RepositoryPatInfo {
   description?: string;
 }
 
+export interface QueuedMessage {
+  messageId: string;
+  content: string;
+  timestamp: number;
+  authorId: string;
+}
+
+export interface ThreadQueue {
+  threadId: string;
+  messages: QueuedMessage[];
+}
+
 export class WorkspaceManager {
   private config: WorkspaceConfig;
 
@@ -66,6 +79,7 @@ export class WorkspaceManager {
       auditDir: join(baseDir, "audit"),
       worktreesDir: join(baseDir, "worktrees"),
       patsDir: join(baseDir, "pats"),
+      queuedMessagesDir: join(baseDir, "queued_messages"),
     };
   }
 
@@ -76,6 +90,7 @@ export class WorkspaceManager {
     await ensureDir(this.config.auditDir);
     await ensureDir(this.config.worktreesDir);
     await ensureDir(this.config.patsDir);
+    await ensureDir(this.config.queuedMessagesDir);
   }
 
   getRepositoriesDir(): string {
@@ -443,6 +458,90 @@ export class WorkspaceManager {
         return [];
       }
       throw error;
+    }
+  }
+
+  private getQueueFilePath(threadId: string): string {
+    return join(this.config.queuedMessagesDir, `${threadId}.json`);
+  }
+
+  async saveMessageQueue(threadQueue: ThreadQueue): Promise<void> {
+    const filePath = this.getQueueFilePath(threadQueue.threadId);
+    await Deno.writeTextFile(filePath, JSON.stringify(threadQueue, null, 2));
+  }
+
+  async loadMessageQueue(threadId: string): Promise<ThreadQueue | null> {
+    try {
+      const filePath = this.getQueueFilePath(threadId);
+      const content = await Deno.readTextFile(filePath);
+      return JSON.parse(content) as ThreadQueue;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async addMessageToQueue(
+    threadId: string,
+    message: QueuedMessage,
+  ): Promise<void> {
+    let queue = await this.loadMessageQueue(threadId);
+    if (!queue) {
+      queue = {
+        threadId,
+        messages: [],
+      };
+    }
+
+    queue.messages.push(message);
+    await this.saveMessageQueue(queue);
+
+    // 監査ログに記録
+    await this.appendAuditLog({
+      timestamp: new Date().toISOString(),
+      threadId,
+      action: "message_queued",
+      details: {
+        messageId: message.messageId,
+        authorId: message.authorId,
+      },
+    });
+  }
+
+  async getAndClearMessageQueue(threadId: string): Promise<QueuedMessage[]> {
+    const queue = await this.loadMessageQueue(threadId);
+    if (!queue || queue.messages.length === 0) {
+      return [];
+    }
+
+    const messages = queue.messages;
+    
+    // キューをクリア
+    await this.deleteMessageQueue(threadId);
+
+    // 監査ログに記録
+    await this.appendAuditLog({
+      timestamp: new Date().toISOString(),
+      threadId,
+      action: "message_queue_cleared",
+      details: {
+        messageCount: messages.length,
+      },
+    });
+
+    return messages;
+  }
+
+  async deleteMessageQueue(threadId: string): Promise<void> {
+    const filePath = this.getQueueFilePath(threadId);
+    try {
+      await Deno.remove(filePath);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
     }
   }
 }

--- a/src/workspace_queue_test.ts
+++ b/src/workspace_queue_test.ts
@@ -1,0 +1,202 @@
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+} from "std/assert/mod.ts";
+import { join } from "std/path/mod.ts";
+import { ensureDir } from "std/fs/mod.ts";
+import { QueuedMessage, WorkspaceManager } from "./workspace.ts";
+
+async function createTestDir(): Promise<string> {
+  const testDir = await Deno.makeTempDir({
+    prefix: "workspace_queue_test_",
+  });
+  return testDir;
+}
+
+Deno.test("WorkspaceManager - メッセージキューの初期化", async () => {
+  const testDir = await createTestDir();
+  try {
+    const manager = new WorkspaceManager(testDir);
+    await manager.initialize();
+
+    // queued_messagesディレクトリが作成されていることを確認
+    const queuedMessagesDir = join(testDir, "queued_messages");
+    const stat = await Deno.stat(queuedMessagesDir);
+    assertEquals(stat.isDirectory, true);
+  } finally {
+    await Deno.remove(testDir, { recursive: true });
+  }
+});
+
+Deno.test("WorkspaceManager - メッセージの追加と読み込み", async () => {
+  const testDir = await createTestDir();
+  try {
+    const manager = new WorkspaceManager(testDir);
+    await manager.initialize();
+
+    const threadId = "test-thread-123";
+    const message: QueuedMessage = {
+      messageId: "msg-123",
+      content: "テストメッセージ",
+      timestamp: Date.now(),
+      authorId: "user-123",
+    };
+
+    // メッセージをキューに追加
+    await manager.addMessageToQueue(threadId, message);
+
+    // キューを読み込み
+    const queue = await manager.loadMessageQueue(threadId);
+    assertExists(queue);
+    assertEquals(queue!.threadId, threadId);
+    assertEquals(queue!.messages.length, 1);
+    assertEquals(queue!.messages[0].messageId, message.messageId);
+    assertEquals(queue!.messages[0].content, message.content);
+    assertEquals(queue!.messages[0].authorId, message.authorId);
+  } finally {
+    await Deno.remove(testDir, { recursive: true });
+  }
+});
+
+Deno.test("WorkspaceManager - 複数メッセージの追加", async () => {
+  const testDir = await createTestDir();
+  try {
+    const manager = new WorkspaceManager(testDir);
+    await manager.initialize();
+
+    const threadId = "test-thread-456";
+    const messages: QueuedMessage[] = [
+      {
+        messageId: "msg-1",
+        content: "メッセージ1",
+        timestamp: Date.now(),
+        authorId: "user-1",
+      },
+      {
+        messageId: "msg-2",
+        content: "メッセージ2",
+        timestamp: Date.now() + 1000,
+        authorId: "user-2",
+      },
+      {
+        messageId: "msg-3",
+        content: "メッセージ3",
+        timestamp: Date.now() + 2000,
+        authorId: "user-1",
+      },
+    ];
+
+    // メッセージを順番に追加
+    for (const msg of messages) {
+      await manager.addMessageToQueue(threadId, msg);
+    }
+
+    // キューを確認
+    const queue = await manager.loadMessageQueue(threadId);
+    assertExists(queue);
+    assertEquals(queue!.messages.length, 3);
+    assertEquals(queue!.messages[0].messageId, "msg-1");
+    assertEquals(queue!.messages[1].messageId, "msg-2");
+    assertEquals(queue!.messages[2].messageId, "msg-3");
+  } finally {
+    await Deno.remove(testDir, { recursive: true });
+  }
+});
+
+Deno.test("WorkspaceManager - キューの取得とクリア", async () => {
+  const testDir = await createTestDir();
+  try {
+    const manager = new WorkspaceManager(testDir);
+    await manager.initialize();
+
+    const threadId = "test-thread-789";
+    const messages: QueuedMessage[] = [
+      {
+        messageId: "msg-a",
+        content: "メッセージA",
+        timestamp: Date.now(),
+        authorId: "user-a",
+      },
+      {
+        messageId: "msg-b",
+        content: "メッセージB",
+        timestamp: Date.now() + 1000,
+        authorId: "user-b",
+      },
+    ];
+
+    // メッセージを追加
+    for (const msg of messages) {
+      await manager.addMessageToQueue(threadId, msg);
+    }
+
+    // キューを取得してクリア
+    const retrievedMessages = await manager.getAndClearMessageQueue(threadId);
+    assertEquals(retrievedMessages.length, 2);
+    assertEquals(retrievedMessages[0].messageId, "msg-a");
+    assertEquals(retrievedMessages[1].messageId, "msg-b");
+
+    // キューがクリアされていることを確認
+    const emptyQueue = await manager.loadMessageQueue(threadId);
+    assertEquals(emptyQueue, null);
+
+    // 再度取得しても空であることを確認
+    const noMessages = await manager.getAndClearMessageQueue(threadId);
+    assertEquals(noMessages.length, 0);
+  } finally {
+    await Deno.remove(testDir, { recursive: true });
+  }
+});
+
+Deno.test("WorkspaceManager - 存在しないキューの処理", async () => {
+  const testDir = await createTestDir();
+  try {
+    const manager = new WorkspaceManager(testDir);
+    await manager.initialize();
+
+    const threadId = "non-existent-thread";
+
+    // 存在しないキューの読み込みはnullを返す
+    const queue = await manager.loadMessageQueue(threadId);
+    assertEquals(queue, null);
+
+    // 存在しないキューの取得は空配列を返す
+    const messages = await manager.getAndClearMessageQueue(threadId);
+    assertEquals(messages.length, 0);
+  } finally {
+    await Deno.remove(testDir, { recursive: true });
+  }
+});
+
+Deno.test("WorkspaceManager - キューの削除", async () => {
+  const testDir = await createTestDir();
+  try {
+    const manager = new WorkspaceManager(testDir);
+    await manager.initialize();
+
+    const threadId = "test-thread-delete";
+    const message: QueuedMessage = {
+      messageId: "msg-del",
+      content: "削除テスト",
+      timestamp: Date.now(),
+      authorId: "user-del",
+    };
+
+    // メッセージを追加
+    await manager.addMessageToQueue(threadId, message);
+
+    // キューが存在することを確認
+    const queue = await manager.loadMessageQueue(threadId);
+    assertExists(queue);
+
+    // キューを削除
+    await manager.deleteMessageQueue(threadId);
+
+    // キューが削除されていることを確認
+    const deletedQueue = await manager.loadMessageQueue(threadId);
+    assertEquals(deletedQueue, null);
+  } finally {
+    await Deno.remove(testDir, { recursive: true });
+  }
+});

--- a/src/workspace_queue_test.ts
+++ b/src/workspace_queue_test.ts
@@ -1,10 +1,5 @@
-import {
-  assertEquals,
-  assertExists,
-  assertRejects,
-} from "std/assert/mod.ts";
+import { assertEquals, assertExists } from "std/assert/mod.ts";
 import { join } from "std/path/mod.ts";
-import { ensureDir } from "std/fs/mod.ts";
 import { QueuedMessage, WorkspaceManager } from "./workspace.ts";
 
 async function createTestDir(): Promise<string> {

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -16,22 +16,13 @@ Deno.test("レートリミット検出とメッセージ作成", async () => {
   // レートリミットメッセージを作成
   const message = admin.createRateLimitMessage(threadId, timestamp);
 
-  // メッセージ内容をチェック
+  // メッセージ内容をチェック（string型に対応）
   assertStringIncludes(
-    message.content,
+    message,
     "Claude Codeのレートリミットに達しました",
   );
-  assertStringIncludes(message.content, "自動で継続しますか？");
-
-  // ボタンコンポーネントをチェック
-  assertEquals(message.components?.length, 1);
-  assertEquals(message.components?.[0].components?.length, 2);
-
-  const buttons = message.components?.[0].components;
-  assertEquals(buttons?.[0].label, "はい - 自動継続する");
-  assertEquals(buttons?.[0].custom_id, `rate_limit_auto_yes_${threadId}`);
-  assertEquals(buttons?.[1].label, "いいえ - 手動で再開する");
-  assertEquals(buttons?.[1].custom_id, `rate_limit_auto_no_${threadId}`);
+  assertStringIncludes(message, "制限解除予定時刻");
+  assertStringIncludes(message, "この時間までに送信されたメッセージは、制限解除後に自動的に処理されます");
 
   await Deno.remove(baseDir, { recursive: true });
 });

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -22,7 +22,10 @@ Deno.test("レートリミット検出とメッセージ作成", async () => {
     "Claude Codeのレートリミットに達しました",
   );
   assertStringIncludes(message, "制限解除予定時刻");
-  assertStringIncludes(message, "この時間までに送信されたメッセージは、制限解除後に自動的に処理されます");
+  assertStringIncludes(
+    message,
+    "この時間までに送信されたメッセージは、制限解除後に自動的に処理されます",
+  );
 
   await Deno.remove(baseDir, { recursive: true });
 });


### PR DESCRIPTION
## 概要
レートリミット時にユーザーが送信したメッセージを自動的にキューに保存し、制限解除後に自動的に処理する機能を実装しました。

## 変更内容

### 1. WorkspaceManagerの拡張
- `QueuedMessage`と`ThreadQueue`型を追加
- メッセージキューの保存・読込・削除機能を実装
- `queued_messages`ディレクトリでキューを永続化

### 2. Adminクラスの改善
- レートリミット中のメッセージを自動的にキューに追加
- ボタンなしのシンプルなレートリミットメッセージに変更
- タイマー終了時にキューのメッセージを優先的に処理
- 自動的にタイマーを設定（ボタン操作不要）

### 3. テストの追加
- `workspace_queue_test.ts`: WorkspaceManagerのキュー機能テスト
- `admin_rate_limit_test.ts`: Adminのレートリミット処理テスト

## 動作仕様

1. レートリミットに達すると、自動的に5分後のタイマーが設定されます
2. レートリミット中にユーザーが送信したメッセージはキューに保存されます
3. 制限解除後、キューに溜まったメッセージが自動的に処理されます
4. キューが空の場合は従来通り「続けて」メッセージが送信されます

## メリット
- ユーザーが「続けて」ボタンを押す必要がなくなりました
- レートリミット中のメッセージが失われることがなくなりました
- よりシームレスなユーザー体験を提供できます

## テスト
新しいテストファイルを追加し、以下の動作を確認：
- メッセージキューの基本操作（追加、読込、削除）
- レートリミット時の自動キュー追加
- タイマー終了時のキュー処理
- エッジケースの処理

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- レートリミット発生時にメッセージをキューに追加し、リミット解除後に自動で順次処理する仕組みを導入しました。
	- レートリミット時の通知内容がシンプルなテキスト表示に変更されました。
	- メッセージキューを永続化し、スレッド単位で管理する機能を追加しました。

- **バグ修正**
	- レートリミット解除時にキュー内のメッセージが正しく処理されるようになりました。

- **テスト**
	- レートリミット時のメッセージキュー処理や自動再開機能に関するテストを追加しました。
	- ワークスペース内のメッセージキュー管理機能のテストを追加しました。
	- レートリミット通知メッセージの形式変更に対応したテストを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->