### PR TITLE
feat: fallback devcontainer機能の実装

### DIFF
--- a/src/admin.ts
+++ b/src/admin.ts
@@ -604,6 +604,16 @@ export class Admin implements IAdmin {
       return await this.handleRateLimitAutoButton(threadId, false);
     }
 
+    // ローカル環境選択ボタン処理
+    if (customId.startsWith(`local_env_${threadId}`)) {
+      return await this.handleLocalEnvButton(threadId);
+    }
+
+    // fallback devcontainer選択ボタン処理
+    if (customId.startsWith(`fallback_devcontainer_${threadId}`)) {
+      return await this.handleFallbackDevcontainerButton(threadId);
+    }
+
     return "未知のボタンが押されました。";
   }
 
@@ -1018,38 +1028,69 @@ export class Admin implements IAdmin {
     });
 
     if (!devcontainerInfo.configExists) {
-      this.logVerbose("devcontainer.json未発見、ローカル環境で実行", {
+      this.logVerbose("devcontainer.json未発見", {
         threadId,
       });
 
-      // devcontainer設定情報を保存（ファイル未存在）
-      const config = {
-        useDevcontainer: false,
-        hasDevcontainerFile: false,
-        hasAnthropicsFeature: false,
-        isStarted: false,
-      };
-      await this.saveDevcontainerConfig(threadId, config);
+      // devcontainer CLIの確認
+      const hasDevcontainerCli = await checkDevcontainerCli();
+      
+      if (!hasDevcontainerCli) {
+        // devcontainer CLI未インストールの場合は通常のローカル環境で実行
+        const config = {
+          useDevcontainer: false,
+          hasDevcontainerFile: false,
+          hasAnthropicsFeature: false,
+          isStarted: false,
+        };
+        await this.saveDevcontainerConfig(threadId, config);
 
+        return {
+          hasDevcontainer: false,
+          message:
+            "devcontainer.jsonが見つかりませんでした。通常のローカル環境でClaudeを実行します。\n\n`--dangerously-skip-permissions`オプションを使用しますか？（権限チェックをスキップします。注意して使用してください）",
+          components: [
+            {
+              type: 1,
+              components: [
+                {
+                  type: 2,
+                  style: 1,
+                  label: "権限チェックあり",
+                  custom_id: `permissions_no_skip_${threadId}`,
+                },
+                {
+                  type: 2,
+                  style: 2,
+                  label: "権限チェックスキップ",
+                  custom_id: `permissions_skip_${threadId}`,
+                },
+              ],
+            },
+          ],
+        };
+      }
+
+      // devcontainer CLIがインストールされている場合はfallback devcontainerの選択肢を提供
       return {
         hasDevcontainer: false,
         message:
-          "devcontainer.jsonが見つかりませんでした。通常のローカル環境でClaudeを実行します。\n\n`--dangerously-skip-permissions`オプションを使用しますか？（権限チェックをスキップします。注意して使用してください）",
+          "devcontainer.jsonが見つかりませんでした。\n\n以下のオプションから選択してください：\n1. 通常のローカル環境でClaudeを実行\n2. fallback devcontainerを使用（標準的な開発環境をコンテナで提供）",
         components: [
           {
             type: 1,
             components: [
               {
                 type: 2,
-                style: 1,
-                label: "権限チェックあり",
-                custom_id: `permissions_no_skip_${threadId}`,
+                style: 2,
+                label: "ローカル環境で実行",
+                custom_id: `local_env_${threadId}`,
               },
               {
                 type: 2,
-                style: 2,
-                label: "権限チェックスキップ",
-                custom_id: `permissions_skip_${threadId}`,
+                style: 1,
+                label: "fallback devcontainerを使用",
+                custom_id: `fallback_devcontainer_${threadId}`,
               },
             ],
           },
@@ -1294,6 +1335,151 @@ export class Admin implements IAdmin {
     await this.saveDevcontainerConfig(threadId, config);
 
     return `通常のローカル環境でClaude実行を設定しました。\n\n準備完了です！何かご質問をどうぞ。`;
+  }
+
+  /**
+   * ローカル環境選択ボタンの処理
+   */
+  private async handleLocalEnvButton(threadId: string): Promise<string> {
+    const worker = this.workers.get(threadId);
+    if (!worker) {
+      return "Workerが見つかりません。";
+    }
+
+    const workerTyped = worker as Worker;
+    workerTyped.setUseDevcontainer(false);
+
+    // devcontainer設定情報を保存
+    const config = {
+      useDevcontainer: false,
+      hasDevcontainerFile: false,
+      hasAnthropicsFeature: false,
+      isStarted: false,
+    };
+    await this.saveDevcontainerConfig(threadId, config);
+
+    return `通常のローカル環境でClaudeを実行します。\n\n\`--dangerously-skip-permissions\`オプションを使用しますか？（権限チェックをスキップします。注意して使用してください）`;
+  }
+
+  /**
+   * fallback devcontainer選択ボタンの処理
+   */
+  private async handleFallbackDevcontainerButton(threadId: string): Promise<string> {
+    const worker = this.workers.get(threadId);
+    if (!worker) {
+      return "Workerが見つかりません。";
+    }
+
+    const workerTyped = worker as Worker;
+    workerTyped.setUseDevcontainer(true);
+    workerTyped.setUseFallbackDevcontainer(true);
+
+    // devcontainer設定情報を保存
+    const config = {
+      useDevcontainer: true,
+      hasDevcontainerFile: false, // fallbackを使用
+      hasAnthropicsFeature: true, // fallbackにはClaude Codeが含まれている
+      useFallback: true,
+      isStarted: false,
+    };
+    await this.saveDevcontainerConfig(threadId, config);
+
+    // fallback devcontainerを起動
+    return "fallback_devcontainer_start_with_progress";
+  }
+
+  /**
+   * 指定されたWorkerのfallback devcontainerを起動する
+   */
+  async startFallbackDevcontainerForWorker(
+    threadId: string,
+    onProgress?: (message: string) => Promise<void>,
+  ): Promise<{
+    success: boolean;
+    message: string;
+  }> {
+    const worker = this.workers.get(threadId);
+    if (!worker) {
+      return {
+        success: false,
+        message: "Workerが見つかりません。",
+      };
+    }
+
+    const repository = worker.getRepository();
+    if (!repository) {
+      return {
+        success: false,
+        message: "リポジトリが設定されていません。",
+      };
+    }
+
+    const repositoryPath = this.workspaceManager.getRepositoryPath(
+      repository.org,
+      repository.repo,
+    );
+
+    this.logVerbose("fallback devcontainer起動開始", {
+      threadId,
+      repositoryPath,
+      hasOnProgress: !!onProgress,
+    });
+
+    // fallback devcontainerを起動
+    const { startFallbackDevcontainer } = await import("./devcontainer.ts");
+    const result = await startFallbackDevcontainer(
+      repositoryPath,
+      onProgress,
+    );
+
+    this.logVerbose("fallback devcontainer起動結果", {
+      threadId,
+      success: result.success,
+      hasContainerId: !!result.containerId,
+      hasError: !!result.error,
+    });
+
+    if (result.success) {
+      // devcontainer設定情報を更新（起動状態とcontainerId）
+      const existingConfig = await this.getDevcontainerConfig(threadId);
+      if (existingConfig) {
+        const updatedConfig = {
+          ...existingConfig,
+          containerId: result.containerId || "unknown",
+          isStarted: true,
+        };
+        await this.saveDevcontainerConfig(threadId, updatedConfig);
+      }
+
+      await this.logAuditEntry(threadId, "fallback_devcontainer_started", {
+        containerId: result.containerId || "unknown",
+      });
+
+      this.logVerbose("fallback devcontainer起動成功、監査ログ記録完了", {
+        threadId,
+        containerId: result.containerId,
+      });
+
+      return {
+        success: true,
+        message:
+          "fallback devcontainerが正常に起動しました。Claude実行環境が準備完了です。",
+      };
+    } else {
+      await this.logAuditEntry(threadId, "fallback_devcontainer_start_failed", {
+        error: result.error,
+      });
+
+      this.logVerbose("fallback devcontainer起動失敗、監査ログ記録完了", {
+        threadId,
+        error: result.error,
+      });
+
+      return {
+        success: false,
+        message: `fallback devcontainerの起動に失敗しました: ${result.error}`,
+      };
+    }
   }
 
   /**

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -1034,7 +1034,7 @@ export class Admin implements IAdmin {
 
       // devcontainer CLIの確認
       const hasDevcontainerCli = await checkDevcontainerCli();
-      
+
       if (!hasDevcontainerCli) {
         // devcontainer CLI未インストールの場合は通常のローカル環境で実行
         const config = {
@@ -1364,7 +1364,9 @@ export class Admin implements IAdmin {
   /**
    * fallback devcontainer選択ボタンの処理
    */
-  private async handleFallbackDevcontainerButton(threadId: string): Promise<string> {
+  private async handleFallbackDevcontainerButton(
+    threadId: string,
+  ): Promise<string> {
     const worker = this.workers.get(threadId);
     if (!worker) {
       return "Workerが見つかりません。";

--- a/src/devcontainer.ts
+++ b/src/devcontainer.ts
@@ -381,10 +381,10 @@ export async function prepareFallbackDevcontainer(
     // fallback_devcontainerディレクトリのパスを取得
     const currentDir = new URL(".", import.meta.url).pathname;
     const fallbackDir = join(currentDir, "..", "fallback_devcontainer");
-    
+
     // .devcontainerディレクトリをリポジトリにコピー
     const targetDevcontainerDir = join(repositoryPath, ".devcontainer");
-    
+
     // ターゲットディレクトリが既に存在する場合はエラー
     try {
       await Deno.stat(targetDevcontainerDir);
@@ -397,16 +397,16 @@ export async function prepareFallbackDevcontainer(
         throw error;
       }
     }
-    
+
     // fallback devcontainerをコピー
     const command = new Deno.Command("cp", {
       args: ["-r", join(fallbackDir, ".devcontainer"), repositoryPath],
       stdout: "piped",
       stderr: "piped",
     });
-    
+
     const { code, stderr } = await command.output();
-    
+
     if (code !== 0) {
       const errorMsg = new TextDecoder().decode(stderr);
       return {
@@ -414,7 +414,7 @@ export async function prepareFallbackDevcontainer(
         error: `fallback devcontainerのコピーに失敗しました: ${errorMsg}`,
       };
     }
-    
+
     return { success: true };
   } catch (error) {
     return {
@@ -439,7 +439,7 @@ export async function startFallbackDevcontainer(
   if (onProgress) {
     await onProgress("📦 fallback devcontainerを準備しています...");
   }
-  
+
   // fallback devcontainerをコピー
   const prepareResult = await prepareFallbackDevcontainer(repositoryPath);
   if (!prepareResult.success) {
@@ -448,12 +448,12 @@ export async function startFallbackDevcontainer(
       error: prepareResult.error,
     };
   }
-  
+
   if (onProgress) {
     await onProgress("✅ fallback devcontainerの準備が完了しました");
     await onProgress("🐳 devcontainerを起動しています...");
   }
-  
+
   // 通常のdevcontainer起動処理を実行
   return await startDevcontainer(repositoryPath, onProgress, ghToken);
 }

--- a/src/devcontainer_fallback_test.ts
+++ b/src/devcontainer_fallback_test.ts
@@ -5,35 +5,35 @@ import { prepareFallbackDevcontainer } from "./devcontainer.ts";
 Deno.test("fallback devcontainer機能", async (t) => {
   await t.step("fallback devcontainerをコピーできる", async () => {
     const tempDir = await Deno.makeTempDir();
-    
+
     try {
       // fallback devcontainerをコピー
       const result = await prepareFallbackDevcontainer(tempDir);
-      
+
       // 成功を確認
       assertEquals(result.success, true);
       assertEquals(result.error, undefined);
-      
+
       // .devcontainerディレクトリが作成されたことを確認
       const devcontainerPath = join(tempDir, ".devcontainer");
       const stat = await Deno.stat(devcontainerPath);
       assertEquals(stat.isDirectory, true);
-      
+
       // devcontainer.jsonがコピーされたことを確認
       const devcontainerJsonPath = join(devcontainerPath, "devcontainer.json");
       const jsonStat = await Deno.stat(devcontainerJsonPath);
       assertEquals(jsonStat.isFile, true);
-      
+
       // devcontainer.jsonの内容を確認
       const content = await Deno.readTextFile(devcontainerJsonPath);
       const config = JSON.parse(content);
       assertExists(config.name);
       assertExists(config.image);
       assertExists(config.features);
-      
+
       // Claude Code featureが含まれていることを確認
       const hasClaudeFeature = Object.keys(config.features).some(
-        (key) => key.includes("anthropics/devcontainer-features")
+        (key) => key.includes("anthropics/devcontainer-features"),
       );
       assertEquals(hasClaudeFeature, true);
     } finally {
@@ -42,37 +42,43 @@ Deno.test("fallback devcontainer機能", async (t) => {
     }
   });
 
-  await t.step(".devcontainerディレクトリが既に存在する場合はエラー", async () => {
-    const tempDir = await Deno.makeTempDir();
-    
-    try {
-      // .devcontainerディレクトリを先に作成
-      const devcontainerPath = join(tempDir, ".devcontainer");
-      await Deno.mkdir(devcontainerPath);
-      
-      // fallback devcontainerをコピー（失敗するはず）
-      const result = await prepareFallbackDevcontainer(tempDir);
-      
-      // エラーを確認
-      assertEquals(result.success, false);
-      assertEquals(result.error, ".devcontainerディレクトリが既に存在します");
-    } finally {
-      // クリーンアップ
-      await Deno.remove(tempDir, { recursive: true });
-    }
-  });
+  await t.step(
+    ".devcontainerディレクトリが既に存在する場合はエラー",
+    async () => {
+      const tempDir = await Deno.makeTempDir();
+
+      try {
+        // .devcontainerディレクトリを先に作成
+        const devcontainerPath = join(tempDir, ".devcontainer");
+        await Deno.mkdir(devcontainerPath);
+
+        // fallback devcontainerをコピー（失敗するはず）
+        const result = await prepareFallbackDevcontainer(tempDir);
+
+        // エラーを確認
+        assertEquals(result.success, false);
+        assertEquals(result.error, ".devcontainerディレクトリが既に存在します");
+      } finally {
+        // クリーンアップ
+        await Deno.remove(tempDir, { recursive: true });
+      }
+    },
+  );
 
   await t.step("fallback_devcontainerディレクトリの存在を確認", async () => {
     // fallback_devcontainerディレクトリが存在することを確認
     const currentDir = new URL(".", import.meta.url).pathname;
     const fallbackDir = join(currentDir, "..", "fallback_devcontainer");
     const fallbackDevcontainerDir = join(fallbackDir, ".devcontainer");
-    
+
     const stat = await Deno.stat(fallbackDevcontainerDir);
     assertEquals(stat.isDirectory, true);
-    
+
     // devcontainer.jsonが存在することを確認
-    const devcontainerJsonPath = join(fallbackDevcontainerDir, "devcontainer.json");
+    const devcontainerJsonPath = join(
+      fallbackDevcontainerDir,
+      "devcontainer.json",
+    );
     const jsonStat = await Deno.stat(devcontainerJsonPath);
     assertEquals(jsonStat.isFile, true);
   });

--- a/src/devcontainer_fallback_test.ts
+++ b/src/devcontainer_fallback_test.ts
@@ -1,0 +1,79 @@
+import { assertEquals, assertExists } from "std/assert/mod.ts";
+import { join } from "std/path/mod.ts";
+import { prepareFallbackDevcontainer } from "./devcontainer.ts";
+
+Deno.test("fallback devcontainer機能", async (t) => {
+  await t.step("fallback devcontainerをコピーできる", async () => {
+    const tempDir = await Deno.makeTempDir();
+    
+    try {
+      // fallback devcontainerをコピー
+      const result = await prepareFallbackDevcontainer(tempDir);
+      
+      // 成功を確認
+      assertEquals(result.success, true);
+      assertEquals(result.error, undefined);
+      
+      // .devcontainerディレクトリが作成されたことを確認
+      const devcontainerPath = join(tempDir, ".devcontainer");
+      const stat = await Deno.stat(devcontainerPath);
+      assertEquals(stat.isDirectory, true);
+      
+      // devcontainer.jsonがコピーされたことを確認
+      const devcontainerJsonPath = join(devcontainerPath, "devcontainer.json");
+      const jsonStat = await Deno.stat(devcontainerJsonPath);
+      assertEquals(jsonStat.isFile, true);
+      
+      // devcontainer.jsonの内容を確認
+      const content = await Deno.readTextFile(devcontainerJsonPath);
+      const config = JSON.parse(content);
+      assertExists(config.name);
+      assertExists(config.image);
+      assertExists(config.features);
+      
+      // Claude Code featureが含まれていることを確認
+      const hasClaudeFeature = Object.keys(config.features).some(
+        (key) => key.includes("anthropics/devcontainer-features")
+      );
+      assertEquals(hasClaudeFeature, true);
+    } finally {
+      // クリーンアップ
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  await t.step(".devcontainerディレクトリが既に存在する場合はエラー", async () => {
+    const tempDir = await Deno.makeTempDir();
+    
+    try {
+      // .devcontainerディレクトリを先に作成
+      const devcontainerPath = join(tempDir, ".devcontainer");
+      await Deno.mkdir(devcontainerPath);
+      
+      // fallback devcontainerをコピー（失敗するはず）
+      const result = await prepareFallbackDevcontainer(tempDir);
+      
+      // エラーを確認
+      assertEquals(result.success, false);
+      assertEquals(result.error, ".devcontainerディレクトリが既に存在します");
+    } finally {
+      // クリーンアップ
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  await t.step("fallback_devcontainerディレクトリの存在を確認", async () => {
+    // fallback_devcontainerディレクトリが存在することを確認
+    const currentDir = new URL(".", import.meta.url).pathname;
+    const fallbackDir = join(currentDir, "..", "fallback_devcontainer");
+    const fallbackDevcontainerDir = join(fallbackDir, ".devcontainer");
+    
+    const stat = await Deno.stat(fallbackDevcontainerDir);
+    assertEquals(stat.isDirectory, true);
+    
+    // devcontainer.jsonが存在することを確認
+    const devcontainerJsonPath = join(fallbackDevcontainerDir, "devcontainer.json");
+    const jsonStat = await Deno.stat(devcontainerJsonPath);
+    assertEquals(jsonStat.isFile, true);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -390,12 +390,13 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
         "📦 fallback devcontainerを起動しています...",
       );
 
-      let logs: string[] = [];
+      const logs: string[] = [];
       let lastUpdateTime = Date.now();
       const updateInterval = 1000; // 1秒
       const maxLogLines = 20;
 
       // タイマーIDを保存
+      // deno-lint-ignore prefer-const
       let timerId: number | undefined;
 
       // 定期的な更新処理

--- a/src/main.ts
+++ b/src/main.ts
@@ -386,8 +386,10 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
       }
     } else if (result === "fallback_devcontainer_start_with_progress") {
       // fallback devcontainerの起動処理
-      await interaction.editReply("📦 fallback devcontainerを起動しています...");
-      
+      await interaction.editReply(
+        "📦 fallback devcontainerを起動しています...",
+      );
+
       let logs: string[] = [];
       let lastUpdateTime = Date.now();
       const updateInterval = 1000; // 1秒
@@ -402,7 +404,8 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
           if (logs.length > 0) {
             const logSection = logs.slice(-maxLogLines).join("\n");
             await interaction.editReply({
-              content: `📦 fallback devcontainerを起動しています...\n\n**ログ:**\n\`\`\`\n${logSection}\n\`\`\`\n\n⏳ 初回起動は数分かかる場合があります。`,
+              content:
+                `📦 fallback devcontainerを起動しています...\n\n**ログ:**\n\`\`\`\n${logSection}\n\`\`\`\n\n⏳ 初回起動は数分かかる場合があります。`,
             });
           }
         } catch (error) {
@@ -420,23 +423,31 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
           async (message) => {
             // 進捗メッセージをログに追加
             logs.push(message);
-            
+
             // 即座の更新が必要なメッセージパターン
             const importantPatterns = [
-              "pulling", "downloading", "extracting", "building",
-              "creating", "starting", "waiting", "complete", "success",
-              "error", "failed"
+              "pulling",
+              "downloading",
+              "extracting",
+              "building",
+              "creating",
+              "starting",
+              "waiting",
+              "complete",
+              "success",
+              "error",
+              "failed",
             ];
-            
-            const isImportant = importantPatterns.some(pattern => 
+
+            const isImportant = importantPatterns.some((pattern) =>
               message.toLowerCase().includes(pattern)
             );
-            
+
             if (isImportant && Date.now() - lastUpdateTime > 500) {
               lastUpdateTime = Date.now();
               await updateProgress();
             }
-          }
+          },
         );
 
         // タイマーをクリア
@@ -446,9 +457,10 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
         if (startResult.success) {
           const finalLogs = logs.slice(-10).join("\n");
           await interaction.editReply({
-            content: `✅ fallback devcontainerが正常に起動しました！\n\n**最終ログ:**\n\`\`\`\n${finalLogs}\n\`\`\`\n\n準備完了です！何かご質問をどうぞ。`,
+            content:
+              `✅ fallback devcontainerが正常に起動しました！\n\n**最終ログ:**\n\`\`\`\n${finalLogs}\n\`\`\`\n\n準備完了です！何かご質問をどうぞ。`,
           });
-          
+
           // ユーザーにメンション付きで通知
           if (interaction.channel && "send" in interaction.channel) {
             await interaction.channel.send(
@@ -457,9 +469,10 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
           }
         } else {
           await interaction.editReply({
-            content: `❌ fallback devcontainerの起動に失敗しました。\n\nエラー: ${startResult.message}`,
+            content:
+              `❌ fallback devcontainerの起動に失敗しました。\n\nエラー: ${startResult.message}`,
           });
-          
+
           // ユーザーにメンション付きで通知
           if (interaction.channel && "send" in interaction.channel) {
             await interaction.channel.send(
@@ -472,10 +485,12 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
         if (timerId) {
           clearInterval(timerId);
         }
-        
+
         console.error("fallback devcontainer起動エラー:", error);
         await interaction.editReply({
-          content: `❌ fallback devcontainerの起動中にエラーが発生しました: ${(error as Error).message}`,
+          content: `❌ fallback devcontainerの起動中にエラーが発生しました: ${
+            (error as Error).message
+          }`,
         });
       }
     } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -384,6 +384,100 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
           );
         }
       }
+    } else if (result === "fallback_devcontainer_start_with_progress") {
+      // fallback devcontainerの起動処理
+      await interaction.editReply("📦 fallback devcontainerを起動しています...");
+      
+      let logs: string[] = [];
+      let lastUpdateTime = Date.now();
+      const updateInterval = 1000; // 1秒
+      const maxLogLines = 20;
+
+      // タイマーIDを保存
+      let timerId: number | undefined;
+
+      // 定期的な更新処理
+      const updateProgress = async () => {
+        try {
+          if (logs.length > 0) {
+            const logSection = logs.slice(-maxLogLines).join("\n");
+            await interaction.editReply({
+              content: `📦 fallback devcontainerを起動しています...\n\n**ログ:**\n\`\`\`\n${logSection}\n\`\`\`\n\n⏳ 初回起動は数分かかる場合があります。`,
+            });
+          }
+        } catch (error) {
+          console.error("進捗更新エラー:", error);
+        }
+      };
+
+      // 定期的な更新タイマーを開始
+      timerId = setInterval(updateProgress, updateInterval);
+
+      try {
+        // fallback devcontainerを起動
+        const startResult = await admin.startFallbackDevcontainerForWorker(
+          threadId,
+          async (message) => {
+            // 進捗メッセージをログに追加
+            logs.push(message);
+            
+            // 即座の更新が必要なメッセージパターン
+            const importantPatterns = [
+              "pulling", "downloading", "extracting", "building",
+              "creating", "starting", "waiting", "complete", "success",
+              "error", "failed"
+            ];
+            
+            const isImportant = importantPatterns.some(pattern => 
+              message.toLowerCase().includes(pattern)
+            );
+            
+            if (isImportant && Date.now() - lastUpdateTime > 500) {
+              lastUpdateTime = Date.now();
+              await updateProgress();
+            }
+          }
+        );
+
+        // タイマーをクリア
+        clearInterval(timerId);
+
+        // 最終結果を更新
+        if (startResult.success) {
+          const finalLogs = logs.slice(-10).join("\n");
+          await interaction.editReply({
+            content: `✅ fallback devcontainerが正常に起動しました！\n\n**最終ログ:**\n\`\`\`\n${finalLogs}\n\`\`\`\n\n準備完了です！何かご質問をどうぞ。`,
+          });
+          
+          // ユーザーにメンション付きで通知
+          if (interaction.channel && "send" in interaction.channel) {
+            await interaction.channel.send(
+              `<@${interaction.user.id}> fallback devcontainerの起動が完了しました！Claude実行環境が準備完了です。`,
+            );
+          }
+        } else {
+          await interaction.editReply({
+            content: `❌ fallback devcontainerの起動に失敗しました。\n\nエラー: ${startResult.message}`,
+          });
+          
+          // ユーザーにメンション付きで通知
+          if (interaction.channel && "send" in interaction.channel) {
+            await interaction.channel.send(
+              `<@${interaction.user.id}> fallback devcontainerの起動に失敗しました。通常環境でClaude実行を継続します。`,
+            );
+          }
+        }
+      } catch (error) {
+        // エラーが発生した場合もタイマーをクリア
+        if (timerId) {
+          clearInterval(timerId);
+        }
+        
+        console.error("fallback devcontainer起動エラー:", error);
+        await interaction.editReply({
+          content: `❌ fallback devcontainerの起動中にエラーが発生しました: ${(error as Error).message}`,
+        });
+      }
     } else {
       await interaction.editReply(result);
     }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -316,6 +316,7 @@ export class Worker implements IWorker {
   // 設定完了状態の管理
   private devcontainerChoiceMade: boolean = false;
   private appendSystemPrompt?: string;
+  private useFallbackDevcontainer: boolean = false;
 
   constructor(
     name: string,
@@ -870,6 +871,23 @@ export class Worker implements IWorker {
    */
   isDevcontainerStarted(): boolean {
     return this.devcontainerStarted;
+  }
+
+  /**
+   * fallback devcontainerの使用を設定する
+   */
+  setUseFallbackDevcontainer(useFallback: boolean): void {
+    this.useFallbackDevcontainer = useFallback;
+    this.logVerbose("fallback devcontainer設定変更", {
+      useFallbackDevcontainer: useFallback,
+    });
+  }
+
+  /**
+   * fallback devcontainerが使用されているかを取得
+   */
+  isUsingFallbackDevcontainer(): boolean {
+    return this.useFallbackDevcontainer;
   }
 
   /**


### PR DESCRIPTION
## Summary
- 対象リポジトリにdevcontainer.jsonがない場合に、fallback_devcontainerディレクトリの設定を使用する選択肢を提供
- 標準的な開発環境をコンテナで提供できるようになり、より多くのリポジトリでdevcontainer機能が利用可能に

## Changes
- `src/admin.ts`: devcontainer.jsonがない場合の選択肢を追加
  - ローカル環境とfallback devcontainerの選択肢を表示
  - fallback devcontainer起動用のハンドラを実装
- `src/devcontainer.ts`: fallback devcontainer用の関数を追加
  - `prepareFallbackDevcontainer`: fallback設定をリポジトリにコピー
  - `startFallbackDevcontainer`: fallback devcontainerを起動
- `src/worker.ts`: fallback devcontainerのサポートを追加
  - `useFallbackDevcontainer`フラグの追加
- `src/main.ts`: fallback devcontainer起動時の進捗表示処理を追加
- `src/devcontainer_fallback_test.ts`: fallback devcontainer機能のテストを追加

## Test Plan
- [x] 既存のテストがすべて通ることを確認
- [x] fallback devcontainer機能の新規テストを追加
- [x] 型チェック、lint、フォーマットが通ることを確認
- [ ] 実際のDiscord環境でfallback devcontainerが起動することを確認
- [ ] fallback devcontainerでClaudeが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - devcontainer.jsonが存在しない場合に、ローカル環境またはフォールバックdevcontainerで実行する選択肢を追加しました。
  - フォールバックdevcontainerの準備と起動が可能になりました。
  - Discord上で選択肢ボタンが表示されるようになりました。
- **バグ修正**
  - devcontainer CLIが未インストール時の案内メッセージを改善しました。
- **テスト**
  - フォールバックdevcontainer機能のテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->