### PR TITLE
fix: スレッド名生成の非同期処理を改善

### DIFF
--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -94,8 +94,13 @@ ${text}`;
 
 export function generateThreadName(
   summary: string,
-  repositoryName: string,
+  repositoryName?: string,
 ): string {
+  // リポジトリ名が提供されていない場合は要約のみを返す
+  if (!repositoryName) {
+    return summary;
+  }
+
   // リポジトリ名から所有者部分を除去（owner/repo -> repo）
   const repoShortName = repositoryName.includes("/")
     ? repositoryName.split("/")[1]

--- a/src/gemini_test.ts
+++ b/src/gemini_test.ts
@@ -11,6 +11,16 @@ Deno.test("generateThreadName - オーナーなしのリポジトリ名でも動
   assertEquals(result, "バグ修正(repo)");
 });
 
+Deno.test("generateThreadName - リポジトリ名なしの場合は要約のみを返す", () => {
+  const result = generateThreadName("新機能の追加");
+  assertEquals(result, "新機能の追加");
+});
+
+Deno.test("generateThreadName - リポジトリ名がundefinedの場合も要約のみを返す", () => {
+  const result = generateThreadName("テストコードの改善", undefined);
+  assertEquals(result, "テストコードの改善");
+});
+
 Deno.test("summarizeWithGemini - API失敗時にエラーを返す", async () => {
   // 無効なAPIキーでテスト
   const result = await summarizeWithGemini("invalid-key", "テストメッセージ");


### PR DESCRIPTION
## Summary
- リポジトリ名がなくても要約のみでスレッド名を生成可能に
- 詳細なログを追加して問題の特定を容易に

## 変更内容
- `generateThreadName`関数でリポジトリ名をオプショナルに変更
- スレッド情報やリポジトリ名がなくても処理を継続できるように修正
- 各処理ステップで`[ThreadRename]`プレフィックス付きの詳細なログを追加
- 関連するテストケースを追加

## Test plan
- [x] 型チェック: `deno task check:quiet` ✅
- [x] テスト: `deno task test:quiet` ✅
- [x] Lint: `deno task lint:quiet` ✅
- [x] フォーマット: `deno task fmt:quiet` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - スレッド名生成機能がリポジトリ名が未指定の場合でも動作するようになりました。

- **バグ修正**
  - リポジトリ名が未指定または`undefined`の場合、スレッド名生成時に正しくサマリーのみが返されるようになりました。

- **テスト**
  - リポジトリ名が未指定または`undefined`の場合の動作を確認するテストケースを追加しました。

- **ドキュメント**
  - スレッド名変更処理に詳細なログ出力を追加し、処理状況の追跡がしやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->