### PR TITLE
fix: devcontainer CLIの有無に依存しないようにテストを修正

### DIFF
--- a/test/admin.test.ts
+++ b/test/admin.test.ts
@@ -197,7 +197,13 @@ Deno.test("Admin - devcontainer.jsonが存在しない場合の設定確認", as
     true,
   );
   assertEquals(Array.isArray(result.components), true);
-  assertEquals(result.message.includes("--dangerously-skip-permissions"), true);
+
+  // devcontainer CLIの有無によってメッセージが変わるため、どちらかの条件を満たすことを確認
+  const hasPermissionsOption = result.message.includes(
+    "--dangerously-skip-permissions",
+  );
+  const hasFallbackOption = result.message.includes("fallback devcontainer");
+  assertEquals(hasPermissionsOption || hasFallbackOption, true);
 
   // クリーンアップ
   await Deno.remove(testRepoDir, { recursive: true });


### PR DESCRIPTION
## Summary
- devcontainer CLIの有無によってテストが失敗する問題を修正

## Test plan
- [x] ローカル環境でテストが成功することを確認
- [x] CI環境でテストが成功することを確認

## Details
`Admin - devcontainer.jsonが存在しない場合の設定確認` テストが、ローカル環境でdevcontainer CLIがインストールされている場合に失敗していました。

原因は、devcontainer CLIの有無によって異なるメッセージが表示されることでした：
- **devcontainer CLIがない場合**: `--dangerously-skip-permissions`オプションの選択肢を表示
- **devcontainer CLIがある場合**: fallback devcontainerの選択肢を表示

この修正により、どちらの環境でもテストが成功するようになりました。

🤖 Generated with [Claude Code](https://claude.ai/code)