### PR TITLE
feat: WorkerとAdminクラスをWorkerState/AdminStateファーストにリファクタリング

### DIFF
--- a/src/admin_devcontainer_test.ts
+++ b/src/admin_devcontainer_test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, assertStringIncludes } from "std/assert/mod.ts";
 import { join } from "std/path/mod.ts";
 import { Admin } from "./admin.ts";
-import { WorkspaceManager } from "./workspace.ts";
+import { AdminState, WorkspaceManager } from "./workspace.ts";
 
 Deno.test("Admin devcontainer機能のテスト", async (t) => {
   const tempDir = await Deno.makeTempDir();
@@ -11,7 +11,11 @@ Deno.test("Admin devcontainer機能のテスト", async (t) => {
   try {
     workspaceManager = new WorkspaceManager(tempDir);
     await workspaceManager.initialize();
-    admin = new Admin(workspaceManager, undefined, undefined);
+    const adminState: AdminState = {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    admin = new Admin(adminState, workspaceManager, undefined, undefined);
 
     await t.step("devcontainer.jsonが存在しない場合のチェック", async () => {
       const repoDir = await Deno.makeTempDir();

--- a/src/admin_rate_limit_test.ts
+++ b/src/admin_rate_limit_test.ts
@@ -1,7 +1,7 @@
 import { assert, assertEquals, assertExists } from "std/assert/mod.ts";
 import { Admin } from "./admin.ts";
 import { ClaudeCodeRateLimitError, IWorker } from "./worker.ts";
-import { QueuedMessage, WorkspaceManager } from "./workspace.ts";
+import { AdminState, QueuedMessage, WorkspaceManager } from "./workspace.ts";
 import { GitRepository } from "./git-utils.ts";
 
 // テスト用の型定義
@@ -70,6 +70,8 @@ class MockWorker implements IWorker {
   isUsingDevcontainer(): boolean {
     return false;
   }
+
+  async save(): Promise<void> {}
 }
 
 Deno.test("Admin - レートリミット時のメッセージキュー追加", async () => {
@@ -78,7 +80,11 @@ Deno.test("Admin - レートリミット時のメッセージキュー追加", a
     const workspaceManager = new WorkspaceManager(testDir);
     await workspaceManager.initialize();
 
-    const admin = new Admin(workspaceManager, undefined, undefined);
+    const adminState: AdminState = {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    const admin = new Admin(adminState, workspaceManager, undefined, undefined);
     const threadId = "test-thread-rate-limit";
 
     // スレッド情報を作成
@@ -146,7 +152,11 @@ Deno.test("Admin - レートリミットエラー時の自動タイマー設定"
     const workspaceManager = new WorkspaceManager(testDir);
     await workspaceManager.initialize();
 
-    const admin = new Admin(workspaceManager, undefined, undefined);
+    const adminState: AdminState = {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    const admin = new Admin(adminState, workspaceManager, undefined, undefined);
     const threadId = "test-thread-auto-timer";
 
     // モックWorkerを作成
@@ -217,7 +227,11 @@ Deno.test("Admin - 自動再開時のキュー処理", async () => {
     const workspaceManager = new WorkspaceManager(testDir);
     await workspaceManager.initialize();
 
-    const admin = new Admin(workspaceManager, undefined, undefined);
+    const adminState: AdminState = {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    const admin = new Admin(adminState, workspaceManager, undefined, undefined);
     const threadId = "test-thread-auto-resume";
 
     // キューにメッセージを追加
@@ -301,7 +315,11 @@ Deno.test("Admin - キューが空の場合は「続けて」を送信", async (
     const workspaceManager = new WorkspaceManager(testDir);
     await workspaceManager.initialize();
 
-    const admin = new Admin(workspaceManager, undefined, undefined);
+    const adminState: AdminState = {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    const admin = new Admin(adminState, workspaceManager, undefined, undefined);
     const threadId = "test-thread-empty-queue";
 
     // スレッド情報を作成

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,10 @@ console.log("\n✅ システム要件チェック完了\n");
 const env = getEnv();
 const workspaceManager = new WorkspaceManager(env.WORK_BASE_DIR);
 await workspaceManager.initialize();
-const admin = new Admin(
+// Admin状態を読み込む
+const adminState = await workspaceManager.loadAdminState();
+const admin = await Admin.fromState(
+  adminState,
   workspaceManager,
   env.VERBOSE,
   env.CLAUDE_APPEND_SYSTEM_PROMPT,

--- a/src/worker_append_system_prompt_test.ts
+++ b/src/worker_append_system_prompt_test.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "https://deno.land/std@0.208.0/testing/asserts.ts";
 import { describe, it } from "https://deno.land/std@0.208.0/testing/bdd.ts";
 import { ClaudeCommandExecutor, Worker } from "./worker.ts";
-import { WorkspaceManager } from "./workspace.ts";
+import { WorkerState, WorkspaceManager } from "./workspace.ts";
 import { parseRepository } from "./git-utils.ts";
 
 class MockClaudeExecutor implements ClaudeCommandExecutor {
@@ -68,16 +68,27 @@ describe("Worker --append-system-prompt オプション", () => {
 
       try {
         // Workerを作成（コンストラクタでmockExecutorを渡す）
+        const state: WorkerState = {
+          workerName: "test-worker",
+          threadId: "test-thread-1",
+          devcontainerConfig: {
+            useDevcontainer: false,
+            useFallbackDevcontainer: false,
+            hasDevcontainerFile: false,
+            hasAnthropicsFeature: false,
+            isStarted: false,
+          },
+          status: "active",
+          createdAt: new Date().toISOString(),
+          lastActiveAt: new Date().toISOString(),
+        };
         const worker = new Worker(
-          "test-worker",
+          state,
           workspaceManager,
           mockExecutor,
           true, // verboseをtrueに設定
           appendPrompt,
         );
-
-        // threadIdを設定してからリポジトリを設定
-        worker.setThreadId("test-thread-1");
 
         const repository = parseRepository("test/repo");
         if (repository) {
@@ -141,17 +152,28 @@ describe("Worker --append-system-prompt オプション", () => {
       await gitInit.output();
 
       try {
-        // Workerを作成（コンストラクタでmockExecutorを渡す）
+        // Workerを作成（コンストラクタでmockExecutorを温す）
+        const state: WorkerState = {
+          workerName: "test-worker",
+          threadId: "test-thread-2",
+          devcontainerConfig: {
+            useDevcontainer: false,
+            useFallbackDevcontainer: false,
+            hasDevcontainerFile: false,
+            hasAnthropicsFeature: false,
+            isStarted: false,
+          },
+          status: "active",
+          createdAt: new Date().toISOString(),
+          lastActiveAt: new Date().toISOString(),
+        };
         const worker = new Worker(
-          "test-worker",
+          state,
           workspaceManager,
           mockExecutor,
           true, // verboseをtrueに設定
           undefined, // appendSystemPrompt未設定
         );
-
-        // threadIdを設定してからリポジトリを設定
-        worker.setThreadId("test-thread-2");
 
         const repository = parseRepository("test/repo");
         if (repository) {

--- a/src/worker_devcontainer_test.ts
+++ b/src/worker_devcontainer_test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "std/assert/mod.ts";
 import { Worker } from "./worker.ts";
-import { WorkspaceManager } from "./workspace.ts";
+import { WorkerState, WorkspaceManager } from "./workspace.ts";
 import { parseRepository } from "./git-utils.ts";
 import { createMockClaudeCommandExecutor } from "../test/test-utils.ts";
 
@@ -13,14 +13,27 @@ Deno.test("Worker devcontainer機能のテスト", async (t) => {
     workspaceManager = new WorkspaceManager(tempDir);
     await workspaceManager.initialize();
 
+    const state: WorkerState = {
+      workerName: "test-worker",
+      threadId: "test-thread-123",
+      devcontainerConfig: {
+        useDevcontainer: false,
+        useFallbackDevcontainer: false,
+        hasDevcontainerFile: false,
+        hasAnthropicsFeature: false,
+        isStarted: false,
+      },
+      status: "active",
+      createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
+    };
     worker = new Worker(
-      "test-worker",
+      state,
       workspaceManager,
       createMockClaudeCommandExecutor("Claude からのテスト応答"),
       undefined,
       undefined,
     );
-    worker.setThreadId("test-thread-123");
 
     await t.step("devcontainerの使用設定", () => {
       assertEquals(worker.isUsingDevcontainer(), false);

--- a/src/worker_extract_output_test.ts
+++ b/src/worker_extract_output_test.ts
@@ -1,15 +1,19 @@
 import { assertEquals } from "https://deno.land/std@0.208.0/testing/asserts.ts";
 import { Worker } from "./worker.ts";
 import { WorkspaceManager } from "./workspace.ts";
-import { createMockClaudeCommandExecutor } from "../test/test-utils.ts";
+import {
+  createMockClaudeCommandExecutor,
+  createTestWorkerState,
+} from "../test/test-utils.ts";
 
 Deno.test("extractOutputMessage - TODOリスト更新（tool_use）を正しく処理する", async () => {
   const tempDir = await Deno.makeTempDir();
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state = createTestWorkerState("test-worker", "test-thread-1");
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     createMockClaudeCommandExecutor(),
     undefined,
@@ -99,8 +103,9 @@ Deno.test("extractOutputMessage - 通常のテキストメッセージを正し�
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state = createTestWorkerState("test-worker", "test-thread-1");
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     createMockClaudeCommandExecutor(),
     undefined,
@@ -143,8 +148,9 @@ Deno.test("extractOutputMessage - resultメッセージは進捗表示しない"
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state = createTestWorkerState("test-worker", "test-thread-1");
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     createMockClaudeCommandExecutor(),
     undefined,
@@ -178,8 +184,9 @@ Deno.test("extractOutputMessage - エラーメッセージを正しく処理す�
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state = createTestWorkerState("test-worker", "test-thread-1");
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     createMockClaudeCommandExecutor(),
     undefined,
@@ -213,8 +220,9 @@ Deno.test("extractOutputMessage - systemメッセージを正しく処理する"
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state = createTestWorkerState("test-worker", "test-thread-system");
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     createMockClaudeCommandExecutor(),
   );
@@ -254,8 +262,9 @@ Deno.test("extractTodoListUpdate - fallback処理でテキストからTODOリス
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state = createTestWorkerState("test-worker", "test-thread-1");
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     createMockClaudeCommandExecutor(),
     undefined,
@@ -292,8 +301,9 @@ Deno.test("extractOutputMessage - Bashツール実行を正しく処理する", 
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state = createTestWorkerState("test-worker", "test-thread-1");
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     createMockClaudeCommandExecutor(),
     undefined,
@@ -335,8 +345,9 @@ Deno.test("extractOutputMessage - ツール結果（tool_result）を正しく�
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state = createTestWorkerState("test-worker", "test-thread-1");
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     createMockClaudeCommandExecutor(),
     undefined,
@@ -378,8 +389,9 @@ Deno.test("extractOutputMessage - エラーツール結果を正しく処理す�
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state = createTestWorkerState("test-worker", "test-thread-1");
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     createMockClaudeCommandExecutor(),
     undefined,
@@ -420,8 +432,9 @@ Deno.test("extractOutputMessage - 短いツール結果を正しく処理する"
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state = createTestWorkerState("test-worker", "test-thread-1");
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     createMockClaudeCommandExecutor(),
     undefined,
@@ -460,8 +473,9 @@ Deno.test("extractOutputMessage - TodoWrite成功メッセージをスキップ�
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state = createTestWorkerState("test-worker", "test-thread-1");
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     createMockClaudeCommandExecutor(),
     undefined,
@@ -500,8 +514,9 @@ Deno.test("extractOutputMessage - TodoWriteエラーメッセージは表示す�
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state = createTestWorkerState("test-worker", "test-thread-1");
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     createMockClaudeCommandExecutor(),
     undefined,
@@ -541,8 +556,9 @@ Deno.test("extractOutputMessage - 長いツール結果をスマート要約す�
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state = createTestWorkerState("test-worker", "test-thread-1");
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     createMockClaudeCommandExecutor(),
     undefined,
@@ -592,8 +608,9 @@ Deno.test("extractOutputMessage - エラー結果から重要部分を抽出す�
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state = createTestWorkerState("test-worker", "test-thread-1");
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     createMockClaudeCommandExecutor(),
     undefined,
@@ -647,8 +664,9 @@ Deno.test("extractOutputMessage - 中程度の長さの結果を先頭末尾で�
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state = createTestWorkerState("test-worker", "test-thread-1");
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     createMockClaudeCommandExecutor(),
     undefined,

--- a/src/worker_task_agent_test.ts
+++ b/src/worker_task_agent_test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "https://deno.land/std@0.208.0/testing/asserts.ts";
 import { Worker } from "./worker.ts";
-import { WorkspaceManager } from "./workspace.ts";
+import { WorkerState, WorkspaceManager } from "./workspace.ts";
 
 // テスト用のClaudeCommandExecutor
 class TestClaudeCommandExecutor {
@@ -18,8 +18,22 @@ Deno.test("extractOutputMessage - タスクエージェントの配列形式tool
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state: WorkerState = {
+    workerName: "test-worker",
+    threadId: "test-thread-1",
+    devcontainerConfig: {
+      useDevcontainer: false,
+      useFallbackDevcontainer: false,
+      hasDevcontainerFile: false,
+      hasAnthropicsFeature: false,
+      isStarted: false,
+    },
+    status: "active",
+    createdAt: new Date().toISOString(),
+    lastActiveAt: new Date().toISOString(),
+  };
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     new TestClaudeCommandExecutor(),
     undefined,
@@ -74,8 +88,22 @@ Deno.test("extractOutputMessage - 複数のテキスト要素を持つ配列形�
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state: WorkerState = {
+    workerName: "test-worker",
+    threadId: "test-thread-1",
+    devcontainerConfig: {
+      useDevcontainer: false,
+      useFallbackDevcontainer: false,
+      hasDevcontainerFile: false,
+      hasAnthropicsFeature: false,
+      isStarted: false,
+    },
+    status: "active",
+    createdAt: new Date().toISOString(),
+    lastActiveAt: new Date().toISOString(),
+  };
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     new TestClaudeCommandExecutor(),
     undefined,
@@ -129,8 +157,22 @@ Deno.test("extractOutputMessage - エラー時の配列形式tool_resultを処�
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state: WorkerState = {
+    workerName: "test-worker",
+    threadId: "test-thread-1",
+    devcontainerConfig: {
+      useDevcontainer: false,
+      useFallbackDevcontainer: false,
+      hasDevcontainerFile: false,
+      hasAnthropicsFeature: false,
+      isStarted: false,
+    },
+    status: "active",
+    createdAt: new Date().toISOString(),
+    lastActiveAt: new Date().toISOString(),
+  };
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     new TestClaudeCommandExecutor(),
     undefined,
@@ -174,8 +216,22 @@ Deno.test("extractOutputMessage - text以外の要素を含む配列は無視す
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state: WorkerState = {
+    workerName: "test-worker",
+    threadId: "test-thread-1",
+    devcontainerConfig: {
+      useDevcontainer: false,
+      useFallbackDevcontainer: false,
+      hasDevcontainerFile: false,
+      hasAnthropicsFeature: false,
+      isStarted: false,
+    },
+    status: "active",
+    createdAt: new Date().toISOString(),
+    lastActiveAt: new Date().toISOString(),
+  };
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     new TestClaudeCommandExecutor(),
     undefined,
@@ -230,8 +286,22 @@ Deno.test("extractOutputMessage - 空の配列形式contentを処理する", asy
   const workspaceManager = new WorkspaceManager(tempDir);
   await workspaceManager.initialize();
 
+  const state: WorkerState = {
+    workerName: "test-worker",
+    threadId: "test-thread-1",
+    devcontainerConfig: {
+      useDevcontainer: false,
+      useFallbackDevcontainer: false,
+      hasDevcontainerFile: false,
+      hasAnthropicsFeature: false,
+      isStarted: false,
+    },
+    status: "active",
+    createdAt: new Date().toISOString(),
+    lastActiveAt: new Date().toISOString(),
+  };
   const worker = new Worker(
-    "test-worker",
+    state,
     workspaceManager,
     new TestClaudeCommandExecutor(),
     undefined,

--- a/src/worker_translation_test.ts
+++ b/src/worker_translation_test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import { Worker } from "./worker.ts";
-import { WorkspaceManager } from "./workspace.ts";
+import { WorkerState, WorkspaceManager } from "./workspace.ts";
 import { parseRepository } from "./git-utils.ts";
 import { ClaudeCommandExecutor } from "./worker.ts";
 
@@ -139,16 +139,28 @@ Deno.test("Worker - 翻訳機能が有効な場合、メッセージが翻訳さ
       }),
     ]);
 
+    const state: WorkerState = {
+      workerName: "test-worker",
+      threadId: "test-thread",
+      devcontainerConfig: {
+        useDevcontainer: false,
+        useFallbackDevcontainer: false,
+        hasDevcontainerFile: false,
+        hasAnthropicsFeature: false,
+        isStarted: false,
+      },
+      status: "active",
+      createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
+    };
     const worker = new Worker(
-      "test-worker",
+      state,
       workspaceManager,
       mockExecutor,
       false,
       undefined,
       "http://localhost:8767", // 翻訳URLを設定
     );
-
-    worker.setThreadId("test-thread");
 
     // devcontainer設定を完了させる
     worker.setUseDevcontainer(false);
@@ -196,16 +208,28 @@ Deno.test("Worker - 翻訳機能が無効な場合、元のメッセージがそ
       }),
     ]);
 
+    const state: WorkerState = {
+      workerName: "test-worker",
+      threadId: "test-thread",
+      devcontainerConfig: {
+        useDevcontainer: false,
+        useFallbackDevcontainer: false,
+        hasDevcontainerFile: false,
+        hasAnthropicsFeature: false,
+        isStarted: false,
+      },
+      status: "active",
+      createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
+    };
     const worker = new Worker(
-      "test-worker",
+      state,
       workspaceManager,
       mockExecutor,
       false,
       undefined,
       undefined, // 翻訳URLなし
     );
-
-    worker.setThreadId("test-thread");
 
     // devcontainer設定を完了させる
     worker.setUseDevcontainer(false);
@@ -252,16 +276,28 @@ Deno.test("Worker - 翻訳APIがエラーの場合、元のメッセージが使
       }),
     ]);
 
+    const state: WorkerState = {
+      workerName: "test-worker",
+      threadId: "test-thread",
+      devcontainerConfig: {
+        useDevcontainer: false,
+        useFallbackDevcontainer: false,
+        hasDevcontainerFile: false,
+        hasAnthropicsFeature: false,
+        isStarted: false,
+      },
+      status: "active",
+      createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
+    };
     const worker = new Worker(
-      "test-worker",
+      state,
       workspaceManager,
       mockExecutor,
       false,
       undefined,
       "http://localhost:9999", // 存在しないサーバー
     );
-
-    worker.setThreadId("test-thread");
 
     // devcontainer設定を完了させる
     worker.setUseDevcontainer(false);
@@ -323,16 +359,28 @@ Deno.test("Worker - VERBOSEモードで翻訳結果がログに出力される",
     };
 
     try {
+      const state: WorkerState = {
+        workerName: "test-worker",
+        threadId: "test-thread",
+        devcontainerConfig: {
+          useDevcontainer: false,
+          useFallbackDevcontainer: false,
+          hasDevcontainerFile: false,
+          hasAnthropicsFeature: false,
+          isStarted: false,
+        },
+        status: "active",
+        createdAt: new Date().toISOString(),
+        lastActiveAt: new Date().toISOString(),
+      };
       const worker = new Worker(
-        "test-worker",
+        state,
         workspaceManager,
         mockExecutor,
         true, // VERBOSEモードを有効化
         undefined,
         "http://localhost:8768",
       );
-
-      worker.setThreadId("test-thread");
 
       // devcontainer設定を完了させる
       worker.setUseDevcontainer(false);

--- a/test/admin.test.ts
+++ b/test/admin.test.ts
@@ -183,7 +183,11 @@ Deno.test("Admin - 未知のボタンIDの場合は適切なメッセージを�
 
 Deno.test("Admin - devcontainer.jsonが存在しない場合の設定確認", async () => {
   const workspace = await createTestWorkspaceManager();
-  const admin = new Admin(workspace, undefined, undefined);
+  const adminState = {
+    activeThreadIds: [],
+    lastUpdated: new Date().toISOString(),
+  };
+  const admin = new Admin(adminState, workspace, undefined, undefined);
   const threadId = "thread-devcontainer-1";
 
   // devcontainer.jsonが存在しないテンポラリディレクトリを作成
@@ -211,7 +215,11 @@ Deno.test("Admin - devcontainer.jsonが存在しない場合の設定確認", as
 
 Deno.test("Admin - devcontainer.jsonが存在する場合の設定確認", async () => {
   const workspace = await createTestWorkspaceManager();
-  const admin = new Admin(workspace, undefined, undefined);
+  const adminState = {
+    activeThreadIds: [],
+    lastUpdated: new Date().toISOString(),
+  };
+  const admin = new Admin(adminState, workspace, undefined, undefined);
   const threadId = "thread-devcontainer-2";
 
   // devcontainer.jsonが存在するテンポラリディレクトリを作成
@@ -244,7 +252,11 @@ Deno.test("Admin - devcontainer.jsonが存在する場合の設定確認", async
 
 Deno.test("Admin - anthropics featureを含むdevcontainer.jsonの設定確認", async () => {
   const workspace = await createTestWorkspaceManager();
-  const admin = new Admin(workspace, undefined, undefined);
+  const adminState = {
+    activeThreadIds: [],
+    lastUpdated: new Date().toISOString(),
+  };
+  const admin = new Admin(adminState, workspace, undefined, undefined);
   const threadId = "thread-devcontainer-3";
 
   // anthropics featureを含むdevcontainer.jsonを作成
@@ -294,7 +306,11 @@ Deno.test("Admin - anthropics featureを含むdevcontainer.jsonの設定確認",
 
 Deno.test("Admin - 初期メッセージにdevcontainer流れの説明が含まれる", async () => {
   const workspace = await createTestWorkspaceManager();
-  const admin = new Admin(workspace, undefined, undefined);
+  const adminState = {
+    activeThreadIds: [],
+    lastUpdated: new Date().toISOString(),
+  };
+  const admin = new Admin(adminState, workspace, undefined, undefined);
   const threadId = "thread-666";
 
   const initialMessage = admin.createInitialMessage(threadId);
@@ -314,11 +330,19 @@ Deno.test("Admin - verboseモードが正しく設定される", async () => {
   const workspace = await createTestWorkspaceManager();
 
   // verboseモード無効でAdminを作成
-  const adminQuiet = new Admin(workspace, false, undefined);
+  const adminStateQuiet = {
+    activeThreadIds: [],
+    lastUpdated: new Date().toISOString(),
+  };
+  const adminQuiet = new Admin(adminStateQuiet, workspace, false, undefined);
   assertEquals(typeof adminQuiet.getWorker, "function");
 
   // verboseモード有効でAdminを作成
-  const adminVerbose = new Admin(workspace, true, undefined);
+  const adminStateVerbose = {
+    activeThreadIds: [],
+    lastUpdated: new Date().toISOString(),
+  };
+  const adminVerbose = new Admin(adminStateVerbose, workspace, true, undefined);
   assertEquals(typeof adminVerbose.getWorker, "function");
 });
 
@@ -334,7 +358,11 @@ Deno.test("Admin - verboseモードでログが出力される", async () => {
 
   try {
     // verboseモード有効でAdminを作成
-    const admin = new Admin(workspace, true, undefined);
+    const adminState = {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    const admin = new Admin(adminState, workspace, true, undefined);
     const threadId = "verbose-test-thread";
 
     // Worker作成（ログが出力される）
@@ -369,7 +397,11 @@ Deno.test("Admin - verboseモード無効時はログが出力されない", asy
 
   try {
     // verboseモード無効でAdminを作成
-    const admin = new Admin(workspace, false, undefined);
+    const adminState = {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    const admin = new Admin(adminState, workspace, false, undefined);
     const threadId = "quiet-test-thread";
 
     // Worker作成
@@ -401,7 +433,11 @@ Deno.test("Admin - verboseモードでのメッセージルーティングログ
 
   try {
     // verboseモード有効でAdminを作成
-    const admin = new Admin(workspace, true, undefined);
+    const adminState = {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    const admin = new Admin(adminState, workspace, true, undefined);
     const threadId = "routing-test-thread";
 
     // Worker作成
@@ -434,7 +470,11 @@ Deno.test("Admin - verboseモードでのメッセージルーティングログ
 
 Deno.test("Admin - devcontainer設定情報を正しく保存・取得できる", async () => {
   const workspace = await createTestWorkspaceManager();
-  const admin = new Admin(workspace, undefined, undefined);
+  const adminState = {
+    activeThreadIds: [],
+    lastUpdated: new Date().toISOString(),
+  };
+  const admin = new Admin(adminState, workspace, undefined, undefined);
   const threadId = "devcontainer-config-test";
 
   // Worker作成
@@ -463,7 +503,11 @@ Deno.test("Admin - devcontainer設定情報を正しく保存・取得できる"
 
 Deno.test("Admin - WorkerStateにdevcontainer設定が永続化される", async () => {
   const workspace = await createTestWorkspaceManager();
-  const admin = new Admin(workspace, undefined, undefined);
+  const adminState = {
+    activeThreadIds: [],
+    lastUpdated: new Date().toISOString(),
+  };
+  const admin = new Admin(adminState, workspace, undefined, undefined);
   const threadId = "devcontainer-persist-test";
 
   // Worker作成
@@ -490,7 +534,11 @@ Deno.test("Admin - WorkerStateにdevcontainer設定が永続化される", async
 
 Deno.test("Admin - 存在しないスレッドのdevcontainer設定取得はnullを返す", async () => {
   const workspace = await createTestWorkspaceManager();
-  const admin = new Admin(workspace, undefined, undefined);
+  const adminState = {
+    activeThreadIds: [],
+    lastUpdated: new Date().toISOString(),
+  };
+  const admin = new Admin(adminState, workspace, undefined, undefined);
 
   const config = await admin.getDevcontainerConfig("non-existent-thread");
 
@@ -501,7 +549,11 @@ Deno.test("Admin - アクティブなスレッドを復旧できる", async () =
   const workspace = await createTestWorkspaceManager();
 
   // 最初のAdminでスレッドを作成・設定
-  const admin1 = new Admin(workspace);
+  const adminState1 = {
+    activeThreadIds: [],
+    lastUpdated: new Date().toISOString(),
+  };
+  const admin1 = new Admin(adminState1, workspace);
   const threadId = "restore-test-thread";
 
   // Worker作成
@@ -520,8 +572,15 @@ Deno.test("Admin - アクティブなスレッドを復旧できる", async () =
   // Workerが存在することを確認
   assertEquals(admin1.getWorker(threadId) !== null, true);
 
+  // Admin状態を保存
+  await admin1.save();
+
   // 新しいAdminを作成（再起動をシミュレート）
-  const admin2 = new Admin(workspace);
+  const adminState2 = await workspace.loadAdminState() || {
+    activeThreadIds: [],
+    lastUpdated: new Date().toISOString(),
+  };
+  const admin2 = new Admin(adminState2, workspace);
 
   // 復旧前はWorkerが存在しない
   assertEquals(admin2.getWorker(threadId), null);
@@ -564,7 +623,11 @@ Deno.test("Admin - アーカイブされたスレッドは復旧されない", a
   await workspace.addActiveThread(threadId);
 
   // Adminを作成してアクティブスレッドを復旧
-  const admin = new Admin(workspace, undefined, undefined);
+  const adminState = await workspace.loadAdminState() || {
+    activeThreadIds: [],
+    lastUpdated: new Date().toISOString(),
+  };
+  const admin = new Admin(adminState, workspace, undefined, undefined);
   await admin.restoreActiveThreads();
 
   // アーカイブされたスレッドは復旧されない
@@ -592,7 +655,11 @@ Deno.test("Admin - 復旧時のエラーハンドリング", async () => {
   await workspace.addActiveThread(threadId);
 
   // Adminを作成してアクティブスレッドを復旧
-  const admin = new Admin(workspace, undefined, undefined);
+  const adminState = await workspace.loadAdminState() || {
+    activeThreadIds: [],
+    lastUpdated: new Date().toISOString(),
+  };
+  const admin = new Admin(adminState, workspace, undefined, undefined);
 
   // エラーハンドリングのため、コンソールエラーをキャプチャ
   const originalConsoleError = console.error;
@@ -648,7 +715,11 @@ Deno.test("Admin - worktreeが存在しないスレッドは復旧時にアー�
   await workspace.addActiveThread(threadId);
 
   // Adminを作成してアクティブスレッドを復旧
-  const admin = new Admin(workspace, undefined, undefined);
+  const adminState = await workspace.loadAdminState() || {
+    activeThreadIds: [],
+    lastUpdated: new Date().toISOString(),
+  };
+  const admin = new Admin(adminState, workspace, undefined, undefined);
   await admin.restoreActiveThreads();
 
   // Workerは作成されない
@@ -684,7 +755,11 @@ Deno.test("Admin - worktreeが存在するスレッドは正常に復旧され�
   await workspace.addActiveThread(threadId);
 
   // Adminを作成してアクティブスレッドを復旧
-  const admin = new Admin(workspace, undefined, undefined);
+  const adminState = await workspace.loadAdminState() || {
+    activeThreadIds: [],
+    lastUpdated: new Date().toISOString(),
+  };
+  const admin = new Admin(adminState, workspace, undefined, undefined);
   await admin.restoreActiveThreads();
 
   // Workerが作成される
@@ -749,7 +824,11 @@ Deno.test("Admin - devcontainer設定がWorkerに正しく復旧される", asyn
   await workspace.addActiveThread(threadId);
 
   // Adminを作成してアクティブスレッドを復旧
-  const admin = new Admin(workspace, undefined, undefined);
+  const adminState = await workspace.loadAdminState() || {
+    activeThreadIds: [],
+    lastUpdated: new Date().toISOString(),
+  };
+  const admin = new Admin(adminState, workspace, undefined, undefined);
   await admin.restoreActiveThreads();
 
   // Workerが作成される
@@ -795,7 +874,11 @@ Deno.test("Admin - devcontainer設定未設定スレッドの復旧", async () =
   await workspace.addActiveThread(threadId);
 
   // Adminを作成してアクティブスレッドを復旧
-  const admin = new Admin(workspace, undefined, undefined);
+  const adminState = await workspace.loadAdminState() || {
+    activeThreadIds: [],
+    lastUpdated: new Date().toISOString(),
+  };
+  const admin = new Admin(adminState, workspace, undefined, undefined);
   await admin.restoreActiveThreads();
 
   // Workerが作成される

--- a/test/devcontainer-pat.test.ts
+++ b/test/devcontainer-pat.test.ts
@@ -1,7 +1,11 @@
 import { assertEquals, assertExists } from "std/assert/mod.ts";
 import { afterEach, beforeEach, describe, it } from "std/testing/bdd.ts";
 import { DevcontainerClaudeExecutor, Worker } from "../src/worker.ts";
-import { RepositoryPatInfo, WorkspaceManager } from "../src/workspace.ts";
+import {
+  RepositoryPatInfo,
+  WorkerState,
+  WorkspaceManager,
+} from "../src/workspace.ts";
 import { GitRepository } from "../src/git-utils.ts";
 
 describe("Devcontainer PAT環境変数設定", () => {
@@ -49,14 +53,27 @@ describe("Devcontainer PAT環境変数設定", () => {
     await workspaceManager.saveRepositoryPat(patInfo);
 
     // Workerを作成
+    const state: WorkerState = {
+      workerName: "test-worker",
+      threadId: "test-thread-id",
+      devcontainerConfig: {
+        useDevcontainer: false,
+        useFallbackDevcontainer: false,
+        hasDevcontainerFile: false,
+        hasAnthropicsFeature: false,
+        isStarted: false,
+      },
+      status: "active",
+      createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
+    };
     const worker = new Worker(
-      "test-worker",
+      state,
       workspaceManager,
       undefined,
       undefined,
       undefined,
     );
-    worker.setThreadId("test-thread-id");
     worker.setUseDevcontainer(true);
 
     // リポジトリを設定
@@ -83,14 +100,27 @@ describe("Devcontainer PAT環境変数設定", () => {
     // PATを保存しない
 
     // Workerを作成
+    const state: WorkerState = {
+      workerName: "test-worker",
+      threadId: "test-thread-id",
+      devcontainerConfig: {
+        useDevcontainer: false,
+        useFallbackDevcontainer: false,
+        hasDevcontainerFile: false,
+        hasAnthropicsFeature: false,
+        isStarted: false,
+      },
+      status: "active",
+      createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
+    };
     const worker = new Worker(
-      "test-worker",
+      state,
       workspaceManager,
       undefined,
       undefined,
       undefined,
     );
-    worker.setThreadId("test-thread-id");
     worker.setUseDevcontainer(true);
 
     // リポジトリを設定

--- a/test/persistence_integration.test.ts
+++ b/test/persistence_integration.test.ts
@@ -29,7 +29,11 @@ Deno.test("永続化統合テスト - スレッド作成から復旧まで完全
 
   try {
     // Phase 1: 初回起動とスレッド作成
-    const admin1 = new Admin(workspace, undefined, undefined);
+    const adminState1 = {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    const admin1 = new Admin(adminState1, workspace, undefined, undefined);
     const threadId = "integration-test-thread";
 
     // Worker作成
@@ -46,8 +50,15 @@ Deno.test("永続化統合テスト - スレッド作成から復旧まで完全
     };
     await admin1.saveDevcontainerConfig(threadId, devcontainerConfig);
 
+    // Admin状態を保存
+    await admin1.save();
+
     // Phase 2: 再起動シミュレーション
-    const admin2 = new Admin(workspace, undefined, undefined);
+    const adminState2 = await workspace.loadAdminState() || {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    const admin2 = new Admin(adminState2, workspace, undefined, undefined);
 
     // 復旧前はWorkerが存在しない
     assertEquals(admin2.getWorker(threadId), null);
@@ -82,7 +93,11 @@ Deno.test("永続化統合テスト - スレッド作成から復旧まで完全
     assertEquals(terminatedThreadInfo?.status, "archived");
 
     // Phase 5: 再度復旧を試行（アーカイブされたスレッドは復旧されない）
-    const admin3 = new Admin(workspace, undefined, undefined);
+    const adminState3 = await workspace.loadAdminState() || {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    const admin3 = new Admin(adminState3, workspace, undefined, undefined);
     await admin3.restoreActiveThreads();
     assertEquals(admin3.getWorker(threadId), null);
   } finally {
@@ -95,7 +110,11 @@ Deno.test("永続化統合テスト - 複数スレッドの管理と復旧", asy
 
   try {
     // Phase 1: 複数スレッドを作成
-    const admin1 = new Admin(workspace, undefined, undefined);
+    const adminState1 = {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    const admin1 = new Admin(adminState1, workspace, undefined, undefined);
     const threadIds = ["thread-1", "thread-2", "thread-3"];
 
     for (const threadId of threadIds) {
@@ -117,8 +136,15 @@ Deno.test("永続化統合テスト - 複数スレッドの管理と復旧", asy
     // 1つのスレッドを終了
     await admin1.terminateThread("thread-2");
 
+    // Admin状態を保存
+    await admin1.save();
+
     // Phase 2: 再起動と復旧
-    const admin2 = new Admin(workspace, undefined, undefined);
+    const adminState2 = await workspace.loadAdminState() || {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    const admin2 = new Admin(adminState2, workspace, undefined, undefined);
     await admin2.restoreActiveThreads();
 
     // Phase 3: 復旧結果確認
@@ -146,7 +172,11 @@ Deno.test("永続化統合テスト - セッションログとワークスペー
 
   try {
     // Phase 1: スレッド作成とセッションログ記録
-    const admin1 = new Admin(workspace, undefined, undefined);
+    const adminState1 = {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    const admin1 = new Admin(adminState1, workspace, undefined, undefined);
     const threadId = "session-log-thread";
 
     await admin1.createWorker(threadId);
@@ -167,7 +197,11 @@ Deno.test("永続化統合テスト - セッションログとワークスペー
     assertEquals(targetThread.status, "active");
 
     // Phase 3: 再起動と復旧
-    const admin2 = new Admin(workspace, undefined, undefined);
+    const adminState2 = {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    const admin2 = new Admin(adminState2, workspace, undefined, undefined);
     await admin2.restoreActiveThreads();
 
     // 復旧後の設定確認
@@ -183,8 +217,15 @@ Deno.test("永続化統合テスト - セッションログとワークスペー
     };
     await admin2.saveDevcontainerConfig(threadId, updatedConfig);
 
+    // Admin状態を保存
+    await admin2.save();
+
     // Phase 5: 再度復旧して変更が永続化されているか確認
-    const admin3 = new Admin(workspace, undefined, undefined);
+    const adminState3 = await workspace.loadAdminState() || {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    const admin3 = new Admin(adminState3, workspace, undefined, undefined);
     await admin3.restoreActiveThreads();
 
     const finalConfig = await admin3.getDevcontainerConfig(threadId);
@@ -201,7 +242,11 @@ Deno.test("永続化統合テスト - エラー耐性と部分復旧", async () 
 
   try {
     // Phase 1: 正常なスレッドと問題のあるスレッドを混在させる
-    const admin1 = new Admin(workspace, undefined, undefined);
+    const adminState1 = {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    const admin1 = new Admin(adminState1, workspace, undefined, undefined);
 
     // 正常なスレッド
     const goodThreadId = "good-thread";
@@ -229,8 +274,18 @@ Deno.test("永続化統合テスト - エラー耐性と部分復旧", async () 
     // アクティブスレッドリストに追加
     await workspace.addActiveThread(badThreadId);
 
+    // Admin状態を保存する前に、最新のAdminStateを取得して保存
+    const currentAdminState = await workspace.loadAdminState();
+    if (currentAdminState) {
+      await workspace.saveAdminState(currentAdminState);
+    }
+
     // Phase 2: 復旧処理（エラーハンドリング）
-    const admin2 = new Admin(workspace, undefined, undefined);
+    const adminState2 = await workspace.loadAdminState() || {
+      activeThreadIds: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    const admin2 = new Admin(adminState2, workspace, undefined, undefined);
 
     // エラーログをキャプチャ
     const originalConsoleError = console.error;

--- a/test/worker-relative-path.test.ts
+++ b/test/worker-relative-path.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
 import { Worker } from "../src/worker.ts";
 import { WorkspaceManager } from "../src/workspace.ts";
+import { createTestWorkerState } from "./test-utils.ts";
 
 class TestWorker extends Worker {
   // テスト用にgetRelativePathをpublicにする
@@ -12,7 +13,7 @@ class TestWorker extends Worker {
   // テスト用にworktreePathを設定できるようにする
   public setWorktreePathForTest(path: string | null): void {
     // @ts-ignore - private プロパティにアクセス
-    this.worktreePath = path;
+    this.state.worktreePath = path;
   }
 }
 
@@ -20,7 +21,8 @@ Deno.test("Worker.getRelativePath - worktreePathが設定されている場合",
   const tempDir = await Deno.makeTempDir();
   try {
     const workspaceManager = new WorkspaceManager(tempDir);
-    const worker = new TestWorker("test-worker", workspaceManager);
+    const state = createTestWorkerState("test-worker", "test-thread-1");
+    const worker = new TestWorker(state, workspaceManager);
 
     // worktreePathを設定
     const worktreePath = "/Users/test/workspace/repositories/org/repo";
@@ -46,7 +48,8 @@ Deno.test("Worker.getRelativePath - リポジトリパターンの場合", async
   const tempDir = await Deno.makeTempDir();
   try {
     const workspaceManager = new WorkspaceManager(tempDir);
-    const worker = new TestWorker("test-worker", workspaceManager);
+    const state = createTestWorkerState("test-worker", "test-thread-1");
+    const worker = new TestWorker(state, workspaceManager);
 
     // worktreePathが未設定
     worker.setWorktreePathForTest(null);
@@ -73,7 +76,8 @@ Deno.test("Worker.getRelativePath - threadsパターンの場合", async () => {
   const tempDir = await Deno.makeTempDir();
   try {
     const workspaceManager = new WorkspaceManager(tempDir);
-    const worker = new TestWorker("test-worker", workspaceManager);
+    const state = createTestWorkerState("test-worker", "test-thread-1");
+    const worker = new TestWorker(state, workspaceManager);
 
     // worktreePathが未設定
     worker.setWorktreePathForTest(null);
@@ -100,7 +104,8 @@ Deno.test("Worker.getRelativePath - 特殊なケース", async () => {
   const tempDir = await Deno.makeTempDir();
   try {
     const workspaceManager = new WorkspaceManager(tempDir);
-    const worker = new TestWorker("test-worker", workspaceManager);
+    const state = createTestWorkerState("test-worker", "test-thread-1");
+    const worker = new TestWorker(state, workspaceManager);
 
     // 空文字列
     assertEquals(worker.testGetRelativePath(""), "");
@@ -126,7 +131,8 @@ Deno.test("Worker.getRelativePath - Discord表示時の実際の使用", async (
   const tempDir = await Deno.makeTempDir();
   try {
     const workspaceManager = new WorkspaceManager(tempDir);
-    const worker = new TestWorker("test-worker", workspaceManager);
+    const state = createTestWorkerState("test-worker", "test-thread-1");
+    const worker = new TestWorker(state, workspaceManager);
 
     // 実際のワークツリーパス例
     const worktreePath =

--- a/test/worker-streaming.test.ts
+++ b/test/worker-streaming.test.ts
@@ -3,6 +3,7 @@ import { Worker } from "../src/worker.ts";
 import {
   createMockStreamingClaudeCommandExecutor,
   createTestRepository,
+  createTestWorkerState,
   createTestWorkspaceManager,
 } from "./test-utils.ts";
 
@@ -25,8 +26,9 @@ Deno.test("Worker - ストリーミング進捗コールバックが呼ばれる
     const allData = streamData.join("");
     mockExecutor.setResponse("test", allData);
 
+    const state = createTestWorkerState("test-worker", "test-thread-1");
     const worker = new Worker(
-      "test-worker",
+      state,
       workspace,
       mockExecutor,
       undefined,
@@ -80,8 +82,9 @@ Deno.test("Worker - エラー時のストリーミング処理", async () => {
     const allData = streamData.join("");
     mockExecutor.setResponse("error test", allData);
 
+    const state = createTestWorkerState("test-worker", "test-thread-1");
     const worker = new Worker(
-      "test-worker",
+      state,
       workspace,
       mockExecutor,
       undefined,
@@ -131,8 +134,9 @@ Deno.test("Worker - 進捗コールバックなしでも動作する", async () 
     const allData = streamData.join("");
     mockExecutor.setResponse("no callback test", allData);
 
+    const state = createTestWorkerState("test-worker", "test-thread-1");
     const worker = new Worker(
-      "test-worker",
+      state,
       workspace,
       mockExecutor,
       undefined,

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -8,6 +8,7 @@ import {
   createMockStreamingClaudeCommandExecutor,
   createTestRepository,
   createTestWorker,
+  createTestWorkerState,
   createTestWorkspaceManager,
   ERROR_MESSAGES,
 } from "./test-utils.ts";
@@ -80,7 +81,23 @@ Deno.test("Worker - 設定未完了時の定型メッセージ", async () => {
   const executor = createMockClaudeCommandExecutor();
 
   try {
-    const worker = await createTestWorker("test-worker", workspace, executor);
+    // devcontainer設定が未完了のWorkerStateを作成
+    const state = createTestWorkerState("test-worker", "test-thread-id", {
+      devcontainerConfig: {
+        useDevcontainer: undefined as unknown as boolean, // 未設定状態
+        useFallbackDevcontainer: false,
+        hasDevcontainerFile: false,
+        hasAnthropicsFeature: false,
+        isStarted: false,
+      },
+    });
+    const worker = new Worker(
+      state,
+      workspace,
+      executor,
+      undefined,
+      undefined,
+    );
     const repository = createTestRepository("octocat", "Hello-World");
     await worker.setRepository(repository, "/test/repo");
 
@@ -156,8 +173,9 @@ Deno.test("Worker - verboseモードでログが出力される", async () => {
   };
 
   try {
+    const state = createTestWorkerState("verbose-worker", "test-thread-1");
     const worker = new Worker(
-      "verbose-worker",
+      state,
       workspace,
       executor,
       true,


### PR DESCRIPTION
## Summary
- WorkerクラスとAdminクラスをstate-firstなアーキテクチャにリファクタリング
- 状態管理の一元化により保守性と型安全性が向上

## Changes

### Worker クラスのリファクタリング
- コンストラクタの第一引数をWorkerStateに変更
- 内部プロパティをWorkerState経由で管理
- save()メソッドでWorkerStateを永続化
- getState()メソッドで状態を公開

### Admin クラスのリファクタリング  
- コンストラクタの第一引数をAdminStateに変更
- 内部状態をAdminStateで一元管理
- save()メソッドでAdminStateを永続化
- fromState()静的メソッドで復元をサポート

### テストの更新
- 全てのWorkerとAdminのテストを新しいコンストラクタに対応
- createTestWorkerState()ヘルパー関数を追加
- 永続化統合テストのバグ修正

## Test plan
- [x] 全てのテストが成功することを確認
- [x] 型チェックが通ることを確認
- [x] lintチェックが通ることを確認
- [x] フォーマットチェックが通ることを確認
- [ ] 実際のDiscord Botとして動作することを確認

Co-Authored-By: Claude <noreply@anthropic.com>