### PR TITLE
refactor: 長大なメソッドを責務ごとに小さなメソッドに分割（Issue #67対応）

### DIFF
--- a/src/admin/message-router.ts
+++ b/src/admin/message-router.ts
@@ -1,4 +1,4 @@
-import { ClaudeCodeRateLimitError } from "../worker.ts";
+import { ClaudeCodeRateLimitError, type IWorker } from "../worker.ts";
 import { WorkspaceManager } from "../workspace.ts";
 import type { AuditEntry } from "../workspace.ts";
 import type { DiscordMessage } from "./types.ts";
@@ -42,53 +42,124 @@ export class MessageRouter {
     });
 
     // メッセージ受信確認のリアクションを追加
-    if (onReaction) {
-      try {
-        await onReaction("👀");
-        this.logVerbose("メッセージ受信リアクション追加完了", { threadId });
-      } catch (error) {
-        this.logVerbose("メッセージ受信リアクション追加エラー", {
-          threadId,
-          error: (error as Error).message,
-        });
-      }
+    await this.addMessageReceivedReaction(threadId, onReaction);
+
+    // VERBOSEモードでの詳細ログ出力
+    this.logMessageDetails(threadId, message);
+
+    // レートリミット確認と処理
+    const rateLimitResult = await this.checkAndHandleRateLimit(
+      threadId,
+      messageId,
+      authorId,
+      message,
+    );
+    if (rateLimitResult) {
+      return rateLimitResult;
     }
 
-    // VERBOSEモードでDiscordユーザーメッセージの詳細ログ
-    if (this.verbose) {
-      console.log(
-        `[${
-          new Date().toISOString()
-        }] [MessageRouter] Discord受信メッセージ詳細:`,
-      );
-      console.log(`  スレッドID: ${threadId}`);
-      console.log(`  メッセージ長: ${message.length}文字`);
-      console.log("  メッセージ内容:");
-      console.log(
-        `    ${message.split("\n").map((line) => `    ${line}`).join("\n")}`,
-      );
-    }
+    // スレッド用のWorker取得
+    const worker = this.findWorkerForThread(threadId);
 
-    // レートリミット中か確認
-    if (
-      await this.rateLimitManager.isRateLimited(threadId) && messageId &&
-      authorId
-    ) {
-      // レートリミット中のメッセージをキューに追加
-      await this.rateLimitManager.queueMessage(
+    // 監査ログに記録
+    await this.logAuditEntry(threadId, "message_received", {
+      messageLength: message.length,
+      hasRepository: worker.getRepository() !== null,
+    });
+
+    this.logVerbose("Workerにメッセージ処理を委譲", { threadId });
+
+    try {
+      // Workerへの処理委譲
+      return await this.delegateToWorker(
+        worker,
         threadId,
-        messageId,
         message,
-        authorId,
+        onProgress,
+        onReaction,
       );
-      return "レートリミット中です。このメッセージは制限解除後に自動的に処理されます。";
+    } catch (error) {
+      // レートリミットエラーのハンドリング
+      return await this.handleRateLimitError(threadId, error);
+    }
+  }
+
+  /**
+   * メッセージ受信リアクションを追加する
+   */
+  private async addMessageReceivedReaction(
+    threadId: string,
+    onReaction?: (emoji: string) => Promise<void>,
+  ): Promise<void> {
+    if (!onReaction) {
+      return;
     }
 
-    const worker = this.workerManager.getWorker(threadId);
-    if (!worker) {
-      this.logVerbose("Worker見つからず", {
+    try {
+      await onReaction("👀");
+      this.logVerbose("メッセージ受信リアクション追加完了", { threadId });
+    } catch (error) {
+      this.logVerbose("メッセージ受信リアクション追加エラー", {
         threadId,
+        error: (error as Error).message,
       });
+    }
+  }
+
+  /**
+   * VERBOSEモードでの詳細ログを出力する
+   */
+  private logMessageDetails(threadId: string, message: string): void {
+    if (!this.verbose) {
+      return;
+    }
+
+    const timestamp = new Date().toISOString();
+    console.log(
+      `[${timestamp}] [MessageRouter] Discord受信メッセージ詳細:`,
+    );
+    console.log(`  スレッドID: ${threadId}`);
+    console.log(`  メッセージ長: ${message.length}文字`);
+    console.log("  メッセージ内容:");
+    console.log(
+      `    ${message.split("\n").map((line) => `    ${line}`).join("\n")}`,
+    );
+  }
+
+  /**
+   * レートリミット状態を確認し、必要に応じて処理する
+   */
+  private async checkAndHandleRateLimit(
+    threadId: string,
+    messageId?: string,
+    authorId?: string,
+    message?: string,
+  ): Promise<string | null> {
+    const isRateLimited = await this.rateLimitManager.isRateLimited(threadId);
+
+    if (!isRateLimited || !messageId || !authorId) {
+      return null;
+    }
+
+    // レートリミット中のメッセージをキューに追加
+    await this.rateLimitManager.queueMessage(
+      threadId,
+      messageId,
+      message || "",
+      authorId,
+    );
+
+    return "レートリミット中です。このメッセージは制限解除後に自動的に処理されます。";
+  }
+
+  /**
+   * スレッド用のWorkerを取得する
+   */
+  private findWorkerForThread(threadId: string): IWorker {
+    const worker = this.workerManager.getWorker(threadId);
+
+    if (!worker) {
+      this.logVerbose("Worker見つからず", { threadId });
       throw new Error(`Worker not found for thread: ${threadId}`);
     }
 
@@ -104,50 +175,61 @@ export class MessageRouter {
       threadId,
     });
 
-    // 監査ログに記録
-    await this.logAuditEntry(threadId, "message_received", {
-      messageLength: message.length,
-      hasRepository: worker.getRepository() !== null,
+    return worker;
+  }
+
+  /**
+   * Workerへメッセージ処理を委譲する
+   */
+  private async delegateToWorker(
+    worker: IWorker,
+    threadId: string,
+    message: string,
+    onProgress?: (content: string) => Promise<void>,
+    onReaction?: (emoji: string) => Promise<void>,
+  ): Promise<string> {
+    const result = await worker.processMessage(
+      message,
+      onProgress,
+      onReaction,
+    );
+
+    this.logVerbose("メッセージ処理完了", {
+      threadId,
+      responseLength: result.length,
     });
 
-    this.logVerbose("Workerにメッセージ処理を委譲", { threadId });
+    return result;
+  }
 
-    try {
-      const result = await worker.processMessage(
-        message,
-        onProgress,
-        onReaction,
-      );
-
-      this.logVerbose("メッセージ処理完了", {
-        threadId,
-        responseLength: result.length,
-      });
-
-      return result;
-    } catch (error) {
-      if (error instanceof ClaudeCodeRateLimitError) {
-        this.logVerbose("Claude Codeレートリミット検出", {
-          threadId,
-          timestamp: error.timestamp,
-        });
-
-        // レートリミット情報をスレッド情報に保存
-        await this.rateLimitManager.saveRateLimitInfo(
-          threadId,
-          error.timestamp,
-        );
-
-        // 自動継続確認メッセージを返す
-        return this.rateLimitManager.createRateLimitMessage(
-          threadId,
-          error.timestamp,
-        );
-      }
-
+  /**
+   * レートリミットエラーをハンドリングする
+   */
+  private async handleRateLimitError(
+    threadId: string,
+    error: unknown,
+  ): Promise<string | DiscordMessage> {
+    if (!(error instanceof ClaudeCodeRateLimitError)) {
       // その他のエラーは再投げ
       throw error;
     }
+
+    this.logVerbose("Claude Codeレートリミット検出", {
+      threadId,
+      timestamp: error.timestamp,
+    });
+
+    // レートリミット情報をスレッド情報に保存
+    await this.rateLimitManager.saveRateLimitInfo(
+      threadId,
+      error.timestamp,
+    );
+
+    // 自動継続確認メッセージを返す
+    return this.rateLimitManager.createRateLimitMessage(
+      threadId,
+      error.timestamp,
+    );
   }
 
   /**

--- a/src/devcontainer.ts
+++ b/src/devcontainer.ts
@@ -106,6 +106,262 @@ export async function checkDevcontainerCli(): Promise<boolean> {
 }
 
 /**
+ * devcontainer起動用の環境変数を準備する
+ */
+function prepareEnvironment(ghToken?: string): Record<string, string> {
+  const env: Record<string, string> = {
+    ...Deno.env.toObject(),
+    DOCKER_DEFAULT_PLATFORM: "linux/amd64",
+  };
+
+  // GitHub PATが提供されている場合は環境変数に設定
+  if (ghToken) {
+    env.GH_TOKEN = ghToken;
+    env.GITHUB_TOKEN = ghToken; // 互換性のため両方設定
+  }
+
+  return env;
+}
+
+/**
+ * devcontainerコマンドを作成する
+ */
+function createDevcontainerCommand(
+  repositoryPath: string,
+  env: Record<string, string>,
+): Deno.Command {
+  return new Deno.Command("devcontainer", {
+    args: [
+      "up",
+      "--workspace-folder",
+      repositoryPath,
+      "--log-level",
+      "debug",
+      "--log-format",
+      "json",
+    ],
+    stdout: "piped",
+    stderr: "piped",
+    cwd: repositoryPath,
+    env,
+  });
+}
+
+/**
+ * 進捗タイマーを設定する
+ */
+function setupProgressTimer(
+  logBuffer: string[],
+  maxLogLines: number,
+  onProgress?: (message: string) => Promise<void>,
+): number {
+  const progressUpdateInterval = 2000; // 2秒
+  return setInterval(async () => {
+    if (onProgress && logBuffer.length > 0) {
+      const recentLogs = logBuffer.slice(-maxLogLines);
+      const logMessage = "🐳 起動中...\n```\n" + recentLogs.join("\n") +
+        "\n```";
+      await onProgress(logMessage).catch(console.error);
+    }
+  }, progressUpdateInterval);
+}
+
+/**
+ * JSONログからメッセージを抽出する
+ */
+function extractLogMessage(logEntry: Record<string, unknown>): {
+  message: string;
+  timestamp: string;
+} {
+  const message = String(
+    logEntry.message || logEntry.msg || JSON.stringify(logEntry),
+  );
+  const timestamp = String(logEntry.timestamp || logEntry.time || "");
+  return { message, timestamp };
+}
+
+/**
+ * 進捗メッセージのアイコンを決定する
+ */
+function getProgressIcon(message: string): string {
+  const lowercaseMessage = message.toLowerCase();
+  if (
+    lowercaseMessage.includes("pulling") ||
+    lowercaseMessage.includes("downloading")
+  ) {
+    return "⬇️";
+  } else if (lowercaseMessage.includes("extracting")) {
+    return "📦";
+  } else if (lowercaseMessage.includes("building")) {
+    return "🔨";
+  } else if (
+    lowercaseMessage.includes("creating") ||
+    lowercaseMessage.includes("starting")
+  ) {
+    return "🚀";
+  } else if (
+    lowercaseMessage.includes("complete") ||
+    lowercaseMessage.includes("success")
+  ) {
+    return "✅";
+  }
+  return "🐳";
+}
+
+/**
+ * 重要なイベントかどうかを判定する
+ */
+function isImportantEvent(message: string): boolean {
+  const lowercaseMessage = message.toLowerCase();
+  const keywords = [
+    "pulling",
+    "downloading",
+    "extracting",
+    "building",
+    "creating",
+    "starting",
+    "running",
+    "container",
+    "image",
+    "layer",
+    "waiting",
+    "complete",
+    "success",
+  ];
+  return keywords.some((keyword) => lowercaseMessage.includes(keyword));
+}
+
+/**
+ * stdout行を処理する
+ */
+async function processStdoutLine(
+  line: string,
+  logBuffer: string[],
+  maxLogLines: number,
+  lastProgressUpdate: { time: number },
+  onProgress?: (message: string) => Promise<void>,
+): Promise<void> {
+  try {
+    const logEntry = JSON.parse(line);
+    const { message, timestamp } = extractLogMessage(logEntry);
+
+    // 読みやすい形式でバッファに追加
+    const formattedLog = timestamp ? `[${timestamp}] ${message}` : message;
+    logBuffer.push(formattedLog);
+
+    // バッファサイズを制限
+    if (logBuffer.length > maxLogLines * 2) {
+      logBuffer.splice(0, logBuffer.length - maxLogLines);
+    }
+
+    // 重要なイベントは即座に通知
+    if (isImportantEvent(message)) {
+      const now = Date.now();
+      if (now - lastProgressUpdate.time > 1000) { // 1秒以上経過していれば更新
+        lastProgressUpdate.time = now;
+        if (onProgress) {
+          const icon = getProgressIcon(message);
+          await onProgress(`${icon} ${message}`).catch(console.error);
+        }
+      }
+    }
+  } catch {
+    // JSON以外の行はそのまま追加
+    logBuffer.push(line);
+    if (logBuffer.length > maxLogLines * 2) {
+      logBuffer.splice(0, logBuffer.length - maxLogLines);
+    }
+  }
+}
+
+/**
+ * ストリーム出力を処理する
+ */
+async function processStreamOutput(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  decoder: TextDecoder,
+  logBuffer: string[],
+  maxLogLines: number,
+  lastProgressUpdate: { time: number },
+  onProgress?: (message: string) => Promise<void>,
+): Promise<string> {
+  let output = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) {
+        const chunk = decoder.decode(value, { stream: true });
+        output += chunk;
+
+        // JSON形式のログをパースして処理
+        const lines = chunk.split("\n").filter((line) => line.trim());
+        for (const line of lines) {
+          await processStdoutLine(
+            line,
+            logBuffer,
+            maxLogLines,
+            lastProgressUpdate,
+            onProgress,
+          );
+        }
+      }
+    }
+  } catch (error) {
+    console.error("stdout読み取りエラー:", error);
+  } finally {
+    reader.releaseLock();
+  }
+  return output;
+}
+
+/**
+ * stderrストリームを読み取る
+ */
+async function readStderrStream(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  decoder: TextDecoder,
+): Promise<string> {
+  let errorOutput = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) {
+        const chunk = decoder.decode(value, { stream: true });
+        errorOutput += chunk;
+      }
+    }
+  } catch (error) {
+    console.error("stderr読み取りエラー:", error);
+  } finally {
+    reader.releaseLock();
+  }
+  return errorOutput;
+}
+
+/**
+ * コンテナIDを抽出する
+ */
+function extractContainerId(output: string): string | undefined {
+  const containerIdMatch = output.match(/container\s+id:\s*([a-f0-9]+)/i);
+  return containerIdMatch?.[1];
+}
+
+/**
+ * 最終メッセージをフォーマットする
+ */
+function formatFinalMessage(
+  logBuffer: string[],
+  containerId?: string,
+): string {
+  const finalLogs = logBuffer.slice(-10).join("\n");
+  return `✅ devcontainerが正常に起動しました\n\n**最終ログ:**\n\`\`\`\n${finalLogs}\n\`\`\`${
+    containerId ? `\n🆔 コンテナID: ${containerId}` : ""
+  }`;
+}
+
+/**
  * devcontainerを起動する
  */
 export async function startDevcontainer(
@@ -128,175 +384,38 @@ export async function startDevcontainer(
       await onProgress("🔧 devcontainer upコマンドを実行中...");
     }
 
-    const env: Record<string, string> = {
-      ...Deno.env.toObject(),
-      DOCKER_DEFAULT_PLATFORM: "linux/amd64",
-    };
-
-    // GitHub PATが提供されている場合は環境変数に設定
-    if (ghToken) {
-      env.GH_TOKEN = ghToken;
-      env.GITHUB_TOKEN = ghToken; // 互換性のため両方設定
-    }
-
-    const command = new Deno.Command("devcontainer", {
-      args: [
-        "up",
-        "--workspace-folder",
-        repositoryPath,
-        "--log-level",
-        "debug",
-        "--log-format",
-        "json",
-      ],
-      stdout: "piped",
-      stderr: "piped",
-      cwd: repositoryPath,
-      env,
-    });
-
+    const env = prepareEnvironment(ghToken);
+    const command = createDevcontainerCommand(repositoryPath, env);
     const process = command.spawn();
+
     const decoder = new TextDecoder();
-    let output = "";
-    let errorOutput = "";
     const logBuffer: string[] = [];
     const maxLogLines = 30;
-    let lastProgressUpdate = Date.now();
-    const progressUpdateInterval = 2000; // 2秒
+    const lastProgressUpdate = { time: Date.now() };
 
     // stdoutとstderrをストリーミングで読み取る
     const stdoutReader = process.stdout.getReader();
     const stderrReader = process.stderr.getReader();
 
     // 定期的なログ更新タイマー
-    const progressTimer = setInterval(async () => {
-      if (onProgress && logBuffer.length > 0) {
-        const recentLogs = logBuffer.slice(-maxLogLines);
-        const logMessage = "🐳 起動中...\n```\n" + recentLogs.join("\n") +
-          "\n```";
-        await onProgress(logMessage).catch(console.error);
-      }
-    }, progressUpdateInterval);
+    const progressTimer = setupProgressTimer(
+      logBuffer,
+      maxLogLines,
+      onProgress,
+    );
 
-    // stdoutの読み取り
-    const stdoutPromise = (async () => {
-      try {
-        while (true) {
-          const { done, value } = await stdoutReader.read();
-          if (done) break;
-          if (value) {
-            const chunk = decoder.decode(value, { stream: true });
-            output += chunk;
-
-            // JSON形式のログをパースして処理
-            const lines = chunk.split("\n").filter((line) => line.trim());
-            for (const line of lines) {
-              try {
-                const logEntry = JSON.parse(line);
-                // ログエントリから意味のあるメッセージを抽出
-                const message = logEntry.message || logEntry.msg || line;
-                const timestamp = logEntry.timestamp || logEntry.time || "";
-
-                // 読みやすい形式でバッファに追加
-                const formattedLog = timestamp
-                  ? `[${timestamp}] ${message}`
-                  : message;
-                logBuffer.push(formattedLog);
-
-                // バッファサイズを制限
-                if (logBuffer.length > maxLogLines * 2) {
-                  logBuffer.splice(0, logBuffer.length - maxLogLines);
-                }
-
-                // 重要なイベントは即座に通知
-                const lowercaseMessage = message.toLowerCase();
-                if (
-                  lowercaseMessage.includes("pulling") ||
-                  lowercaseMessage.includes("downloading") ||
-                  lowercaseMessage.includes("extracting") ||
-                  lowercaseMessage.includes("building") ||
-                  lowercaseMessage.includes("creating") ||
-                  lowercaseMessage.includes("starting") ||
-                  lowercaseMessage.includes("running") ||
-                  lowercaseMessage.includes("container") ||
-                  lowercaseMessage.includes("image") ||
-                  lowercaseMessage.includes("layer") ||
-                  lowercaseMessage.includes("waiting") ||
-                  lowercaseMessage.includes("complete") ||
-                  lowercaseMessage.includes("success")
-                ) {
-                  const now = Date.now();
-                  if (now - lastProgressUpdate > 1000) { // 1秒以上経過していれば更新
-                    lastProgressUpdate = now;
-                    if (onProgress) {
-                      // 特定のイベントにアイコンを付与
-                      let icon = "🐳";
-                      if (
-                        lowercaseMessage.includes("pulling") ||
-                        lowercaseMessage.includes("downloading")
-                      ) {
-                        icon = "⬇️";
-                      } else if (lowercaseMessage.includes("extracting")) {
-                        icon = "📦";
-                      } else if (lowercaseMessage.includes("building")) {
-                        icon = "🔨";
-                      } else if (
-                        lowercaseMessage.includes("creating") ||
-                        lowercaseMessage.includes("starting")
-                      ) {
-                        icon = "🚀";
-                      } else if (
-                        lowercaseMessage.includes("complete") ||
-                        lowercaseMessage.includes("success")
-                      ) {
-                        icon = "✅";
-                      }
-                      await onProgress(`${icon} ${message}`).catch(
-                        console.error,
-                      );
-                    }
-                  }
-                }
-              } catch {
-                // JSON以外の行はそのまま追加
-                logBuffer.push(line);
-                if (logBuffer.length > maxLogLines * 2) {
-                  logBuffer.splice(0, logBuffer.length - maxLogLines);
-                }
-              }
-            }
-          }
-        }
-      } catch (error) {
-        console.error("stdout読み取りエラー:", error);
-      } finally {
-        stdoutReader.releaseLock();
-      }
-    })();
-
-    // stderrの読み取り
-    const stderrPromise = (async () => {
-      try {
-        while (true) {
-          const { done, value } = await stderrReader.read();
-          if (done) break;
-          if (value) {
-            const chunk = decoder.decode(value, { stream: true });
-            errorOutput += chunk;
-          }
-        }
-      } catch (error) {
-        console.error("stderr読み取りエラー:", error);
-      } finally {
-        stderrReader.releaseLock();
-      }
-    })();
-
-    // プロセスの終了とストリーミング読み取りの完了を待つ
-    const [{ code }] = await Promise.all([
+    // ストリーム読み取りを並列実行
+    const [{ code }, output, errorOutput] = await Promise.all([
       process.status,
-      stdoutPromise,
-      stderrPromise,
+      processStreamOutput(
+        stdoutReader,
+        decoder,
+        logBuffer,
+        maxLogLines,
+        lastProgressUpdate,
+        onProgress,
+      ),
+      readStderrStream(stderrReader, decoder),
     ]);
 
     // タイマーをクリア
@@ -314,18 +433,12 @@ export async function startDevcontainer(
       };
     }
 
-    // コンテナIDを取得（出力から抽出）
-    const containerIdMatch = output.match(/container\s+id:\s*([a-f0-9]+)/i);
-    const containerId = containerIdMatch?.[1];
+    // コンテナIDを取得
+    const containerId = extractContainerId(output);
 
     // 最終的なログサマリーを送信
     if (onProgress) {
-      const finalLogs = logBuffer.slice(-10).join("\n");
-      await onProgress(
-        `✅ devcontainerが正常に起動しました\n\n**最終ログ:**\n\`\`\`\n${finalLogs}\n\`\`\`${
-          containerId ? `\n🆔 コンテナID: ${containerId}` : ""
-        }`,
-      );
+      await onProgress(formatFinalMessage(logBuffer, containerId));
     }
 
     return {


### PR DESCRIPTION
## 概要

Issue #67で指摘された長大なメソッドをリファクタリングし、各メソッドを20-30行以内の小さなメソッドに分割しました。

## 変更内容

### 優先度: 高

#### 1. Worker.executeClaudeStreaming（222行 → 95行）
以下のメソッドに分割：
- `processStreamLine`: 1行のJSON処理
- `handleAssistantMessage`: アシスタントメッセージの処理
- `handleResultMessage`: 結果メッセージの処理とレート制限エラー検出
- `handleErrorMessage`: エラー時のログ出力
- `saveSessionData`: セッションIDの更新とJSONLログの保存
- `handleStreamData`: ストリームデータのバッファリングと行単位処理
- `finalizeStreamProcessing`: セッションデータの保存と最終結果の返却

#### 2. DevcontainerManager.checkAndSetupDevcontainer（192行 → 43行）
以下のメソッドに分割：
- `checkDevcontainerExistence`: devcontainer.json存在確認
- `handleNoDevcontainerCase`: devcontainer.json未発見時の処理
- `handleNoCliCase`: CLI未インストール時の処理
- `prepareDevcontainerResponse`: devcontainer設定時の応答準備
- `createLocalEnvResponse`: ローカル環境選択肢の作成
- `createFallbackDevcontainerResponse`: fallback devcontainer選択肢の作成
- `createPermissionButtons`: 権限チェックボタンの作成
- `createDevcontainerButtons`: devcontainer使用選択ボタンの作成

#### 3. DevContainer.startDevcontainer（231行 → 74行）
以下のメソッドに分割：
- `prepareEnvironment`: 環境変数の準備
- `createDevcontainerCommand`: devcontainerコマンドの作成
- `setupProgressTimer`: 進捗タイマーの設定
- `extractLogMessage`: JSONログからメッセージ抽出
- `getProgressIcon`: 進捗メッセージに応じたアイコン決定
- `isImportantEvent`: 重要なイベントかどうかの判定
- `processStdoutLine`: stdout行の処理
- `processStreamOutput`: ストリーム出力全体の処理
- `readStderrStream`: stderrストリームの読み取り
- `extractContainerId`: コンテナID抽出
- `formatFinalMessage`: 最終メッセージの整形

#### 4. GitUtils.createWorktreeCopy（133行 → 24行）
以下のメソッドに分割：
- `generateBranchName`: ブランチ名の生成ロジック共通化
- `copyRepository`: rsyncでリポジトリをコピー
- `checkGitDirectory`: .gitディレクトリの存在確認
- `createNewBranch`: 新しいブランチを作成
- `initializeNewRepository`: 新規リポジトリとして初期化
- `configureGitUser`: Gitユーザー設定
- `stageAndCommitFiles`: ファイルのステージングとコミット
- `renameBranch`: ブランチ名を設定

### 優先度: 中

#### 5. Admin.restoreActiveThreads（86行 → 30行）
以下のメソッドに分割：
- `checkActiveThreads`: アクティブスレッドの存在確認
- `loadAndValidateThreadInfo`: スレッド情報の読み込みと検証
- `restoreSingleThread`: 単一スレッドの復旧処理
- `recordThreadRestoration`: スレッド復旧の監査ログ記録
- `handleThreadRestoreError`: エラーハンドリング

#### 6. MessageRouter.routeMessage（123行 → 42行）
以下のメソッドに分割：
- `addMessageReceivedReaction`: メッセージ受信リアクションの追加
- `logMessageDetails`: VERBOSEモードでの詳細ログ出力
- `checkAndHandleRateLimit`: レートリミット確認と処理
- `findWorkerForThread`: スレッド用のWorker取得
- `delegateToWorker`: Workerへの処理委譲
- `handleRateLimitError`: レートリミットエラーのハンドリング

## 効果

- **可読性の向上**: 各メソッドが単一の責務を持ち、名前から処理内容が明確
- **保守性の向上**: 20-30行以内の小さなメソッドで理解しやすい
- **テスタビリティの向上**: 小さな単位でテスト可能
- **責務の明確化**: 単一責務の原則に従った設計

## テスト

- ✅ すべての既存テストが通過（235/235）
- ✅ 型チェック成功
- ✅ Lintチェック成功
- ✅ フォーマット適用済み

## 関連Issue

- Closes #67

🤖 Generated with [Claude Code](https://claude.ai/code)