### PR TITLE
refactor: devcontainerとfallback_devcontainerの進捗表示ロジックを共通化

### DIFF
--- a/src/admin/admin.ts
+++ b/src/admin/admin.ts
@@ -1,5 +1,4 @@
 import type { IWorker } from "../worker.ts";
-import { Worker } from "../worker.ts";
 import { WorkspaceManager } from "../workspace.ts";
 import type { AdminState, AuditEntry, ThreadInfo } from "../workspace.ts";
 import type { AdminError, DiscordMessage, IAdmin } from "./types.ts";
@@ -283,7 +282,7 @@ export class Admin implements IAdmin {
         const result = await this.devcontainerManager
           .handleDevcontainerYesButton(
             threadId,
-            workerResult.value as Worker,
+            workerResult.value,
           );
         return ok(result);
       }
@@ -296,7 +295,7 @@ export class Admin implements IAdmin {
         const result = await this.devcontainerManager
           .handleDevcontainerNoButton(
             threadId,
-            workerResult.value as Worker,
+            workerResult.value,
           );
         return ok(result);
       }
@@ -326,7 +325,7 @@ export class Admin implements IAdmin {
         }
         const result = await this.devcontainerManager.handleLocalEnvButton(
           threadId,
-          workerResult.value as Worker,
+          workerResult.value,
         );
         return ok(result);
       }
@@ -340,7 +339,7 @@ export class Admin implements IAdmin {
         const result = await this.devcontainerManager
           .handleFallbackDevcontainerButton(
             threadId,
-            workerResult.value as Worker,
+            workerResult.value,
           );
         return ok(result);
       }
@@ -374,7 +373,7 @@ export class Admin implements IAdmin {
 
     return this.devcontainerManager.startDevcontainerForWorker(
       threadId,
-      worker as Worker,
+      worker,
       onProgress,
     );
   }

--- a/src/admin/devcontainer-manager.ts
+++ b/src/admin/devcontainer-manager.ts
@@ -3,7 +3,7 @@ import {
   checkDevcontainerConfig,
   startFallbackDevcontainer,
 } from "../devcontainer.ts";
-import type { Worker } from "../worker.ts";
+import type { IWorker } from "../worker.ts";
 import type { AuditEntry } from "../workspace.ts";
 import { WorkspaceManager } from "../workspace.ts";
 import type { DiscordActionRow } from "./types.ts";
@@ -305,7 +305,7 @@ export class DevcontainerManager {
    */
   async startDevcontainerForWorker(
     threadId: string,
-    worker: Worker,
+    worker: IWorker,
     onProgress?: (message: string) => Promise<void>,
   ): Promise<{
     success: boolean;
@@ -448,7 +448,7 @@ export class DevcontainerManager {
    */
   async handleDevcontainerYesButton(
     threadId: string,
-    worker: Worker,
+    worker: IWorker,
   ): Promise<string> {
     worker.setUseDevcontainer(true);
 
@@ -472,7 +472,7 @@ export class DevcontainerManager {
    */
   async handleDevcontainerNoButton(
     threadId: string,
-    worker: Worker,
+    worker: IWorker,
   ): Promise<string> {
     worker.setUseDevcontainer(false);
 
@@ -495,7 +495,7 @@ export class DevcontainerManager {
    */
   async handleLocalEnvButton(
     threadId: string,
-    worker: Worker,
+    worker: IWorker,
   ): Promise<string> {
     worker.setUseDevcontainer(false);
 
@@ -516,7 +516,7 @@ export class DevcontainerManager {
    */
   async handleFallbackDevcontainerButton(
     threadId: string,
-    worker: Worker,
+    worker: IWorker,
   ): Promise<string> {
     worker.setUseDevcontainer(true);
     worker.setUseFallbackDevcontainer(true);

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import { Admin } from "./admin.ts";
 import { Worker } from "./worker.ts";
 import { getEnv } from "./env.ts";
 import { ensureRepository, parseRepository } from "./git-utils.ts";
+import { createDevcontainerProgressHandler } from "./utils/devcontainer-progress.ts";
 import { RepositoryPatInfo, WorkspaceManager } from "./workspace.ts";
 import {
   checkSystemRequirements,
@@ -290,108 +291,74 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
         "devcontainerの起動を開始しました。進捗は下のメッセージで確認できます。",
       );
 
-      let lastUpdateTime = Date.now();
-      const UPDATE_INTERVAL = 1000; // 1秒ごとに更新可能
-      let accumulatedLogs: string[] = [];
-      const MAX_LOG_LINES = 20; // 表示する最大ログ行数
-
-      // 進捗更新用のコールバック（既存メッセージを編集）
-      const onProgress = async (content: string) => {
-        const now = Date.now();
-
-        // ログを蓄積
-        if (content.includes("```")) {
-          // コードブロック内のログを抽出
-          const match = content.match(/```\n([\s\S]*?)\n```/);
-          if (match) {
-            const logLines = match[1].split("\n").filter((line) => line.trim());
-            accumulatedLogs.push(...logLines);
-            // 最新のログのみ保持
-            if (accumulatedLogs.length > MAX_LOG_LINES) {
-              accumulatedLogs = accumulatedLogs.slice(-MAX_LOG_LINES);
-            }
-          }
-        } else {
-          // 通常のメッセージはそのまま追加
-          accumulatedLogs.push(content);
-          if (accumulatedLogs.length > MAX_LOG_LINES) {
-            accumulatedLogs = accumulatedLogs.slice(-MAX_LOG_LINES);
-          }
-        }
-
-        // 更新間隔をチェック
-        if (now - lastUpdateTime >= UPDATE_INTERVAL && progressMessage) {
-          try {
-            // メッセージを更新
-            const logContent = accumulatedLogs.length > 0
-              ? `\n\`\`\`\n${accumulatedLogs.join("\n")}\n\`\`\``
-              : "";
-            await progressMessage.edit({
-              content: `🐳 **devcontainer起動中...**${logContent}`,
-            });
-            lastUpdateTime = now;
-          } catch (editError) {
-            console.error("メッセージ編集エラー:", editError);
-          }
-        }
-      };
-
-      // devcontainerを起動
-      const startResult = await admin.startDevcontainerForWorker(
-        threadId,
-        onProgress,
+      // 共通の進捗ハンドラーを作成
+      const progressHandler = createDevcontainerProgressHandler(
+        interaction,
+        progressMessage,
+        {
+          initialMessage: "🐳 devcontainerを起動しています...",
+          progressPrefix: "🐳 **devcontainer起動中...**",
+          successMessage:
+            "✅ **devcontainer起動完了！**\n\n準備完了です！何かご質問をどうぞ。",
+          failurePrefix: "❌ **devcontainer起動失敗**\n\n",
+        },
       );
 
-      const worker = admin.getWorker(threadId);
+      try {
+        // devcontainerを起動
+        const startResult = await admin.startDevcontainerForWorker(
+          threadId,
+          progressHandler.onProgress,
+        );
 
-      if (startResult.success) {
-        // 最終的な成功メッセージでプログレスメッセージを更新
-        if (progressMessage) {
-          try {
-            await progressMessage.edit({
-              content:
-                `✅ **devcontainer起動完了！**\n\n${startResult.message}\n\n準備完了です！何かご質問をどうぞ。`,
-            });
-          } catch (editError) {
-            console.error("最終メッセージ編集エラー:", editError);
-            // 編集に失敗した場合は新規メッセージを送信
-            if (interaction.channel && "send" in interaction.channel) {
-              await interaction.channel.send(
-                `<@${interaction.user.id}> ${startResult.message}\n\n準備完了です！何かご質問をどうぞ。`,
-              );
+        const worker = admin.getWorker(threadId);
+
+        if (startResult.success) {
+          // 成功時の処理
+          await progressHandler.onSuccess([]);
+
+          // 成功メッセージに追加情報を付与
+          if (progressMessage && startResult.message) {
+            try {
+              const currentContent = progressMessage.content;
+              await progressMessage.edit({
+                content: currentContent.replace(
+                  "準備完了です！何かご質問をどうぞ。",
+                  `${startResult.message}\n\n準備完了です！何かご質問をどうぞ。`,
+                ),
+              });
+            } catch (editError) {
+              console.error("追加情報編集エラー:", editError);
             }
           }
-        }
 
-        // ユーザーにメンション付きで通知
-        if (interaction.channel && "send" in interaction.channel) {
-          await interaction.channel.send(
-            `<@${interaction.user.id}> devcontainerの準備が完了しました！`,
+          // ユーザーにメンション付きで通知
+          if (interaction.channel && "send" in interaction.channel) {
+            await interaction.channel.send(
+              `<@${interaction.user.id}> devcontainerの準備が完了しました！`,
+            );
+          }
+        } else {
+          if (worker) {
+            (worker as unknown as Worker).setUseDevcontainer(false);
+          }
+
+          // 失敗時の処理
+          await progressHandler.onFailure(
+            `${startResult.message}\n\n通常環境でClaude実行を継続します。`,
+            [],
           );
-        }
-      } else {
-        if (worker) {
-          (worker as unknown as Worker).setUseDevcontainer(false);
-        }
 
-        // エラーメッセージでプログレスメッセージを更新
-        if (progressMessage) {
-          try {
-            await progressMessage.edit({
-              content:
-                `❌ **devcontainer起動失敗**\n\n${startResult.message}\n\n通常環境でClaude実行を継続します。`,
-            });
-          } catch (editError) {
-            console.error("エラーメッセージ編集エラー:", editError);
+          // ユーザーにメンション付きで通知
+          if (interaction.channel && "send" in interaction.channel) {
+            await interaction.channel.send(
+              `<@${interaction.user.id}> devcontainerの起動に失敗しました。通常環境でClaude実行を継続します。`,
+            );
           }
         }
-
-        // ユーザーにメンション付きで通知
-        if (interaction.channel && "send" in interaction.channel) {
-          await interaction.channel.send(
-            `<@${interaction.user.id}> devcontainerの起動に失敗しました。通常環境でClaude実行を継続します。`,
-          );
-        }
+      } catch (error) {
+        progressHandler.cleanup();
+        throw error;
       }
     } else if (result === "fallback_devcontainer_start_with_progress") {
       // fallback devcontainerの起動処理
@@ -399,77 +366,31 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
         "📦 fallback devcontainerを起動しています...",
       );
 
-      const logs: string[] = [];
-      let lastUpdateTime = Date.now();
-      const updateInterval = 1000; // 1秒
-      const maxLogLines = 20;
-
-      // タイマーIDを保存
-      // deno-lint-ignore prefer-const
-      let timerId: number | undefined;
-
-      // 定期的な更新処理
-      const updateProgress = async () => {
-        try {
-          if (logs.length > 0) {
-            const logSection = logs.slice(-maxLogLines).join("\n");
-            await interaction.editReply({
-              content:
-                `📦 fallback devcontainerを起動しています...\n\n**ログ:**\n\`\`\`\n${logSection}\n\`\`\`\n\n⏳ 初回起動は数分かかる場合があります。`,
-            });
-          }
-        } catch (error) {
-          console.error("進捗更新エラー:", error);
-        }
-      };
-
-      // 定期的な更新タイマーを開始
-      timerId = setInterval(updateProgress, updateInterval);
+      // 共通の進捗ハンドラーを作成
+      const progressHandler = createDevcontainerProgressHandler(
+        interaction,
+        undefined, // fallbackはeditReplyを使用するのでprogressMessageは不要
+        {
+          initialMessage: "📦 fallback devcontainerを起動しています...",
+          progressPrefix: "📦 fallback devcontainerを起動しています...",
+          successMessage:
+            "✅ fallback devcontainerが正常に起動しました！\n\n準備完了です！何かご質問をどうぞ。",
+          failurePrefix:
+            "❌ fallback devcontainerの起動に失敗しました。\n\nエラー: ",
+          showFirstTimeWarning: true,
+        },
+      );
 
       try {
         // fallback devcontainerを起動
         const startResult = await admin.startFallbackDevcontainerForWorker(
           threadId,
-          async (message) => {
-            // 進捗メッセージをログに追加
-            logs.push(message);
-
-            // 即座の更新が必要なメッセージパターン
-            const importantPatterns = [
-              "pulling",
-              "downloading",
-              "extracting",
-              "building",
-              "creating",
-              "starting",
-              "waiting",
-              "complete",
-              "success",
-              "error",
-              "failed",
-            ];
-
-            const isImportant = importantPatterns.some((pattern) =>
-              message.toLowerCase().includes(pattern)
-            );
-
-            if (isImportant && Date.now() - lastUpdateTime > 500) {
-              lastUpdateTime = Date.now();
-              await updateProgress();
-            }
-          },
+          progressHandler.onProgress,
         );
 
-        // タイマーをクリア
-        clearInterval(timerId);
-
-        // 最終結果を更新
         if (startResult.success) {
-          const finalLogs = logs.slice(-10).join("\n");
-          await interaction.editReply({
-            content:
-              `✅ fallback devcontainerが正常に起動しました！\n\n**最終ログ:**\n\`\`\`\n${finalLogs}\n\`\`\`\n\n準備完了です！何かご質問をどうぞ。`,
-          });
+          // 成功時の処理
+          await progressHandler.onSuccess([]);
 
           // ユーザーにメンション付きで通知
           if (interaction.channel && "send" in interaction.channel) {
@@ -478,10 +399,11 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
             );
           }
         } else {
-          await interaction.editReply({
-            content:
-              `❌ fallback devcontainerの起動に失敗しました。\n\nエラー: ${startResult.message}`,
-          });
+          // 失敗時の処理
+          await progressHandler.onFailure(
+            startResult.message || "不明なエラー",
+            [],
+          );
 
           // ユーザーにメンション付きで通知
           if (interaction.channel && "send" in interaction.channel) {
@@ -491,11 +413,7 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
           }
         }
       } catch (error) {
-        // エラーが発生した場合もタイマーをクリア
-        if (timerId) {
-          clearInterval(timerId);
-        }
-
+        progressHandler.cleanup();
         console.error("fallback devcontainer起動エラー:", error);
         await interaction.editReply({
           content: `❌ fallback devcontainerの起動中にエラーが発生しました: ${

--- a/src/main.ts
+++ b/src/main.ts
@@ -311,7 +311,7 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
           progressHandler.onProgress,
         );
 
-        const worker = admin.getWorker(threadId);
+        const workerResult = admin.getWorker(threadId);
 
         if (startResult.success) {
           // 成功時の処理
@@ -339,8 +339,8 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
             );
           }
         } else {
-          if (worker) {
-            (worker as unknown as Worker).setUseDevcontainer(false);
+          if (workerResult.isOk()) {
+            workerResult.value.setUseDevcontainer(false);
           }
 
           // 失敗時の処理

--- a/src/utils/devcontainer-progress.ts
+++ b/src/utils/devcontainer-progress.ts
@@ -1,5 +1,8 @@
-import { ChatInputCommandInteraction, Message } from "discord.js";
-import { ButtonInteraction } from "discord.js";
+import {
+  ButtonInteraction,
+  ChatInputCommandInteraction,
+  Message,
+} from "discord.js";
 
 export interface DevcontainerProgressOptions {
   /** 初期メッセージ */
@@ -49,7 +52,7 @@ export function createDevcontainerProgressHandler(
 
   const logs: string[] = [];
   let lastUpdateTime = Date.now();
-  let timerId: number | undefined;
+  let timerId: ReturnType<typeof setInterval> | undefined;
 
   // 重要なイベントパターン
   const importantPatterns = [

--- a/src/utils/devcontainer-progress.ts
+++ b/src/utils/devcontainer-progress.ts
@@ -1,0 +1,219 @@
+import { ChatInputCommandInteraction, Message } from "discord.js";
+import { ButtonInteraction } from "discord.js";
+
+export interface DevcontainerProgressOptions {
+  /** 初期メッセージ */
+  initialMessage: string;
+  /** 進行中のメッセージプレフィックス */
+  progressPrefix: string;
+  /** 成功時のメッセージ */
+  successMessage: string;
+  /** 失敗時のメッセージプレフィックス */
+  failurePrefix: string;
+  /** 最大ログ行数 */
+  maxLogLines?: number;
+  /** 更新間隔（ミリ秒） */
+  updateInterval?: number;
+  /** 初回起動の警告メッセージを表示するか */
+  showFirstTimeWarning?: boolean;
+}
+
+export interface DevcontainerProgressHandler {
+  /** 進捗更新関数 */
+  onProgress: (message: string) => Promise<void>;
+  /** 成功時の処理 */
+  onSuccess: (logs: string[]) => Promise<void>;
+  /** 失敗時の処理 */
+  onFailure: (error: string, logs: string[]) => Promise<void>;
+  /** クリーンアップ処理 */
+  cleanup: () => void;
+}
+
+/**
+ * devcontainer起動時の進捗表示を管理する共通関数
+ */
+export function createDevcontainerProgressHandler(
+  interaction: ChatInputCommandInteraction | ButtonInteraction,
+  progressMessage: Message | undefined,
+  options: DevcontainerProgressOptions,
+): DevcontainerProgressHandler {
+  const {
+    initialMessage,
+    progressPrefix,
+    successMessage,
+    failurePrefix,
+    maxLogLines = 20,
+    updateInterval = 1000,
+    showFirstTimeWarning = false,
+  } = options;
+
+  const logs: string[] = [];
+  let lastUpdateTime = Date.now();
+  let timerId: number | undefined;
+
+  // 重要なイベントパターン
+  const importantPatterns = [
+    "pulling",
+    "downloading",
+    "extracting",
+    "building",
+    "creating",
+    "starting",
+    "waiting",
+    "complete",
+    "success",
+    "error",
+    "failed",
+  ];
+
+  /**
+   * ログをフォーマットして返す
+   */
+  const formatLogs = (logLines: string[]): string => {
+    const displayLogs = logLines.slice(-maxLogLines);
+    return displayLogs.length > 0
+      ? `\n\n**ログ:**\n\`\`\`\n${displayLogs.join("\n")}\n\`\`\``
+      : "";
+  };
+
+  /**
+   * 進捗メッセージを更新する
+   */
+  const updateProgress = async () => {
+    try {
+      const logContent = formatLogs(logs);
+      const warningMessage = showFirstTimeWarning
+        ? "\n\n⏳ 初回起動は数分かかる場合があります。"
+        : "";
+
+      const content = `${progressPrefix}${logContent}${warningMessage}`;
+
+      if (progressMessage) {
+        // 既存メッセージを編集（通常のdevcontainer）
+        await progressMessage.edit({ content });
+      } else {
+        // interaction.editReplyを使用（fallback devcontainer）
+        await interaction.editReply({ content });
+      }
+    } catch (error) {
+      console.error("進捗更新エラー:", error);
+    }
+  };
+
+  /**
+   * 定期更新タイマーを開始
+   */
+  const startTimer = () => {
+    timerId = setInterval(updateProgress, updateInterval);
+  };
+
+  /**
+   * メッセージが重要かどうかを判定
+   */
+  const isImportantMessage = (message: string): boolean => {
+    const lowercaseMessage = message.toLowerCase();
+    return importantPatterns.some((pattern) =>
+      lowercaseMessage.includes(pattern)
+    );
+  };
+
+  /**
+   * 進捗メッセージを処理
+   */
+  const onProgress = async (message: string) => {
+    // ログに追加
+    if (message.includes("```")) {
+      // コードブロック内のログを抽出
+      const match = message.match(/```\n([\s\S]*?)\n```/);
+      if (match) {
+        const logLines = match[1].split("\n").filter((line) => line.trim());
+        logs.push(...logLines);
+      }
+    } else {
+      // 通常のメッセージはそのまま追加
+      logs.push(message);
+    }
+
+    // ログサイズを制限
+    if (logs.length > maxLogLines * 2) {
+      logs.splice(0, logs.length - maxLogLines);
+    }
+
+    // 重要なメッセージの場合は即座に更新
+    if (isImportantMessage(message)) {
+      const now = Date.now();
+      if (now - lastUpdateTime >= updateInterval / 2) {
+        lastUpdateTime = now;
+        await updateProgress();
+      }
+    }
+  };
+
+  /**
+   * 成功時の処理
+   */
+  const onSuccess = async (finalLogs: string[]) => {
+    if (timerId) {
+      clearInterval(timerId);
+    }
+
+    const logContent = formatLogs(finalLogs.length > 0 ? finalLogs : logs);
+    const content = `${successMessage}${logContent}`;
+
+    try {
+      if (progressMessage) {
+        await progressMessage.edit({ content });
+      } else {
+        await interaction.editReply({ content });
+      }
+    } catch (error) {
+      console.error("成功メッセージ更新エラー:", error);
+    }
+  };
+
+  /**
+   * 失敗時の処理
+   */
+  const onFailure = async (error: string, failureLogs: string[]) => {
+    if (timerId) {
+      clearInterval(timerId);
+    }
+
+    const logContent = formatLogs(failureLogs.length > 0 ? failureLogs : logs);
+    const content = `${failurePrefix}${error}${logContent}`;
+
+    try {
+      if (progressMessage) {
+        await progressMessage.edit({ content });
+      } else {
+        await interaction.editReply({ content });
+      }
+    } catch (error) {
+      console.error("失敗メッセージ更新エラー:", error);
+    }
+  };
+
+  /**
+   * クリーンアップ処理
+   */
+  const cleanup = () => {
+    if (timerId) {
+      clearInterval(timerId);
+    }
+  };
+
+  // 初期メッセージを設定し、タイマーを開始
+  if (progressMessage) {
+    progressMessage.edit({ content: initialMessage }).catch(console.error);
+  } else {
+    interaction.editReply({ content: initialMessage }).catch(console.error);
+  }
+  startTimer();
+
+  return {
+    onProgress,
+    onSuccess,
+    onFailure,
+    cleanup,
+  };
+}

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -33,5 +33,10 @@ export interface IWorker {
   ): Promise<import("neverthrow").Result<void, WorkerError>>;
   setThreadId(threadId: string): void;
   isUsingDevcontainer(): boolean;
+  setUseDevcontainer(useDevcontainer: boolean): void;
+  setUseFallbackDevcontainer(useFallback: boolean): void;
+  startDevcontainer(
+    onProgress?: (message: string) => Promise<void>,
+  ): Promise<{ success: boolean; containerId?: string; error?: string }>;
   save(): Promise<import("neverthrow").Result<void, WorkerError>>;
 }


### PR DESCRIPTION
## Summary
- devcontainerとfallback_devcontainerの進捗メッセージ表示ロジックを共通化しました
- 新規ファイル`src/utils/devcontainer-progress.ts`に共通関数`createDevcontainerProgressHandler`を実装
- main.tsの重複コードを削除し、保守性を向上させました

## Changes
1. **新規ファイル追加**
   - `src/utils/devcontainer-progress.ts`: 進捗表示の共通ロジックを提供

2. **main.tsの改善**
   - 通常のdevcontainer起動処理で共通関数を使用
   - fallback devcontainer起動処理で共通関数を使用
   - 重複コード163行を削除

## Features
- progressMessage（通常）とeditReply（fallback）の両方に対応
- 重要なメッセージの即時更新機能
- タイマーによる定期更新
- エラー時の自動クリーンアップ

## Test plan
- [x] 型チェック、lint、フォーマット、全テストが通過
- [x] pre-commit/pre-pushフックでの検証完了
- [ ] 実際のDiscord環境でdevcontainer起動時の進捗表示が正しく動作することを確認
- [ ] fallback devcontainerの進捗表示も同様に確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **リファクタリング**
  - devcontainerの進行状況報告ロジックを統一的なハンドラーに置き換え、処理の簡素化とエラーハンドリングの一元化を実現しました。
  - 管理クラス内の型キャストを削除し、コードの簡素化を行いました。
  - devcontainer管理メソッドの引数型をインターフェースに変更しました。

- **新機能**
  - devcontainerの起動進行状況やログをDiscord上で段階的に表示・管理する機能を追加しました。
  - devcontainerの利用設定や起動処理を管理するための新しいメソッドをワーカーインターフェースに追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->