### PR TITLE
feat: スレッドクローズ時にdevcontainerを自動削除

### DIFF
--- a/src/admin/admin.ts
+++ b/src/admin/admin.ts
@@ -483,6 +483,10 @@ export class Admin implements IAdmin {
         this.logVerbose("自動再開タイマークリア", { threadId });
         this.rateLimitManager.clearAutoResumeTimer(threadId);
 
+        // devcontainerの削除
+        this.logVerbose("devcontainer削除", { threadId });
+        await this.devcontainerManager.removeDevcontainer(threadId);
+
         // WorkerStateをアーカイブ状態に更新
         const workerState = await this.workspaceManager.loadWorkerState(
           threadId,

--- a/src/admin/admin.ts
+++ b/src/admin/admin.ts
@@ -477,15 +477,15 @@ export class Admin implements IAdmin {
           repositoryFullName: worker.getRepository()?.fullName,
         });
 
+        // devcontainerの削除を先に実行
+        this.logVerbose("devcontainer削除", { threadId });
+        await this.devcontainerManager.removeDevcontainer(threadId);
+
         this.logVerbose("worktree削除開始", { threadId });
         await this.workspaceManager.removeWorktree(threadId);
 
         this.logVerbose("自動再開タイマークリア", { threadId });
         this.rateLimitManager.clearAutoResumeTimer(threadId);
-
-        // devcontainerの削除
-        this.logVerbose("devcontainer削除", { threadId });
-        await this.devcontainerManager.removeDevcontainer(threadId);
 
         // WorkerStateをアーカイブ状態に更新
         const workerState = await this.workspaceManager.loadWorkerState(


### PR DESCRIPTION
## Summary
- スレッドクローズ時にdevcontainerコンテナを自動的に削除する機能を追加
- リソースリークを防ぎ、不要なコンテナがシステムに残らないように改善
- docker rm -f -v コマンドでコンテナとボリュームを完全削除

## Changes
- `DevcontainerManager`に`removeDevcontainer`メソッドを追加
- `Admin.terminateThread`メソッドでdevcontainer削除処理を呼び出すよう修正
- 存在しないコンテナの場合はエラーとせず正常終了する処理を実装
- 削除成功時は監査ログに記録

## Test plan
- [x] DevcontainerManagerの削除機能の単体テスト追加
- [x] Adminクラスのスレッド終了処理でdevcontainerが削除されることを確認するテスト追加
- [x] 既存テストが全て通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - スレッド終了時に関連するDevcontainerが自動的に削除されるようになりました。

- **バグ修正**
  - 存在しないコンテナIDや未起動のDevcontainerに対しても、削除処理が安全に行われるよう改善されました。

- **テスト**
  - Devcontainerの削除処理やスレッド終了時の動作を検証するテストケースが追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->