### PR TITLE
fix: ignoreされているテストを修正して有効化

### DIFF
--- a/src/worker_translation_test.ts
+++ b/src/worker_translation_test.ts
@@ -374,7 +374,7 @@ Deno.test("Worker - 翻訳APIがエラーの場合、元のメッセージが使
   }
 });
 
-Deno.test.ignore(
+Deno.test(
   "Worker - VERBOSEモードで翻訳結果がログに出力される",
   async () => {
     const tempDir = await Deno.makeTempDir();
@@ -386,8 +386,18 @@ Deno.test.ignore(
       await workspaceManager.initialize();
 
       const mockExecutor = new MockClaudeCommandExecutor([
-        JSON.stringify({ type: "session", session_id: "test-session" }),
-        JSON.stringify({ type: "result", result: "Done!" }),
+        JSON.stringify({
+          type: "system",
+          subtype: "init",
+          session_id: "test-session",
+        }),
+        JSON.stringify({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          session_id: "test-session",
+          result: "Done!",
+        }),
       ]);
 
       // consoleログをキャプチャ


### PR DESCRIPTION
## Summary
- worker_translation_test.tsの「VERBOSEモードで翻訳結果がログに出力される」テストを修正
- rate-limit.test.tsの2つのレートリミットタイマー復旧テストを修正
- 全てのテストを有効化（ignoreを削除）

## 修正内容

### 1. worker_translation_test.ts
- MockClaudeCommandExecutorが返すJSONレスポンスの形式を修正
- 実際のClaude CLIのスキーマに準拠した形式に変更
  - `type: "session"` → `type: "system", subtype: "init"`
  - resultメッセージに必須フィールドを追加

### 2. rate-limit.test.ts
- privateプロパティ`autoResumeTimers`への直接アクセスを削除
- 新しいアーキテクチャ（RateLimitManager）に対応した検証方法に変更
- Worker状態の変化を観測することでタイマーの動作を間接的に確認

## Test plan
- [x] 全てのテストが成功することを確認（265件）
- [x] 型チェック、lint、フォーマットが全て成功
- [x] ignoreされていた3つのテストが正常に動作

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **テスト**
  - 一部の無効化されていたテストが有効化され、検証内容が強化されました。
  - テストの検証方法が改善され、より詳細な状態確認やクリーンアップ処理が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->