### PR TITLE
refactor: WorkerへのunsafeなキャストをIWorkerインターフェースの拡張で解決

### DIFF
--- a/src/admin/admin.ts
+++ b/src/admin/admin.ts
@@ -1,5 +1,4 @@
 import type { IWorker } from "../worker.ts";
-import { Worker } from "../worker.ts";
 import { WorkspaceManager } from "../workspace.ts";
 import type { AdminState, AuditEntry, ThreadInfo } from "../workspace.ts";
 import type { AdminError, DiscordMessage, IAdmin } from "./types.ts";
@@ -283,7 +282,7 @@ export class Admin implements IAdmin {
         const result = await this.devcontainerManager
           .handleDevcontainerYesButton(
             threadId,
-            workerResult.value as Worker,
+            workerResult.value,
           );
         return ok(result);
       }
@@ -296,7 +295,7 @@ export class Admin implements IAdmin {
         const result = await this.devcontainerManager
           .handleDevcontainerNoButton(
             threadId,
-            workerResult.value as Worker,
+            workerResult.value,
           );
         return ok(result);
       }
@@ -326,7 +325,7 @@ export class Admin implements IAdmin {
         }
         const result = await this.devcontainerManager.handleLocalEnvButton(
           threadId,
-          workerResult.value as Worker,
+          workerResult.value,
         );
         return ok(result);
       }
@@ -340,7 +339,7 @@ export class Admin implements IAdmin {
         const result = await this.devcontainerManager
           .handleFallbackDevcontainerButton(
             threadId,
-            workerResult.value as Worker,
+            workerResult.value,
           );
         return ok(result);
       }
@@ -374,7 +373,7 @@ export class Admin implements IAdmin {
 
     return this.devcontainerManager.startDevcontainerForWorker(
       threadId,
-      worker as Worker,
+      worker,
       onProgress,
     );
   }

--- a/src/admin/devcontainer-manager.ts
+++ b/src/admin/devcontainer-manager.ts
@@ -3,7 +3,7 @@ import {
   checkDevcontainerConfig,
   startFallbackDevcontainer,
 } from "../devcontainer.ts";
-import type { Worker } from "../worker.ts";
+import type { IWorker } from "../worker.ts";
 import type { AuditEntry } from "../workspace.ts";
 import { WorkspaceManager } from "../workspace.ts";
 import type { DiscordActionRow } from "./types.ts";
@@ -305,7 +305,7 @@ export class DevcontainerManager {
    */
   async startDevcontainerForWorker(
     threadId: string,
-    worker: Worker,
+    worker: IWorker,
     onProgress?: (message: string) => Promise<void>,
   ): Promise<{
     success: boolean;
@@ -448,7 +448,7 @@ export class DevcontainerManager {
    */
   async handleDevcontainerYesButton(
     threadId: string,
-    worker: Worker,
+    worker: IWorker,
   ): Promise<string> {
     worker.setUseDevcontainer(true);
 
@@ -472,7 +472,7 @@ export class DevcontainerManager {
    */
   async handleDevcontainerNoButton(
     threadId: string,
-    worker: Worker,
+    worker: IWorker,
   ): Promise<string> {
     worker.setUseDevcontainer(false);
 
@@ -495,7 +495,7 @@ export class DevcontainerManager {
    */
   async handleLocalEnvButton(
     threadId: string,
-    worker: Worker,
+    worker: IWorker,
   ): Promise<string> {
     worker.setUseDevcontainer(false);
 
@@ -516,7 +516,7 @@ export class DevcontainerManager {
    */
   async handleFallbackDevcontainerButton(
     threadId: string,
-    worker: Worker,
+    worker: IWorker,
   ): Promise<string> {
     worker.setUseDevcontainer(true);
     worker.setUseFallbackDevcontainer(true);

--- a/src/main.ts
+++ b/src/main.ts
@@ -311,7 +311,7 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
           progressHandler.onProgress,
         );
 
-        const worker = admin.getWorker(threadId);
+        const workerResult = admin.getWorker(threadId);
 
         if (startResult.success) {
           // 成功時の処理
@@ -339,8 +339,8 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
             );
           }
         } else {
-          if (worker) {
-            (worker as unknown as Worker).setUseDevcontainer(false);
+          if (workerResult.isOk()) {
+            workerResult.value.setUseDevcontainer(false);
           }
 
           // 失敗時の処理

--- a/src/utils/devcontainer-progress.ts
+++ b/src/utils/devcontainer-progress.ts
@@ -1,5 +1,8 @@
-import { ChatInputCommandInteraction, Message } from "discord.js";
-import { ButtonInteraction } from "discord.js";
+import {
+  ButtonInteraction,
+  ChatInputCommandInteraction,
+  Message,
+} from "discord.js";
 
 export interface DevcontainerProgressOptions {
   /** 初期メッセージ */
@@ -49,7 +52,7 @@ export function createDevcontainerProgressHandler(
 
   const logs: string[] = [];
   let lastUpdateTime = Date.now();
-  let timerId: number | undefined;
+  let timerId: ReturnType<typeof setInterval> | undefined;
 
   // 重要なイベントパターン
   const importantPatterns = [

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -33,5 +33,10 @@ export interface IWorker {
   ): Promise<import("neverthrow").Result<void, WorkerError>>;
   setThreadId(threadId: string): void;
   isUsingDevcontainer(): boolean;
+  setUseDevcontainer(useDevcontainer: boolean): void;
+  setUseFallbackDevcontainer(useFallback: boolean): void;
+  startDevcontainer(
+    onProgress?: (message: string) => Promise<void>,
+  ): Promise<{ success: boolean; containerId?: string; error?: string }>;
   save(): Promise<import("neverthrow").Result<void, WorkerError>>;
 }


### PR DESCRIPTION
- IWorkerインターフェースにsetUseDevcontainer、setUseFallbackDevcontainer、startDevcontainerメソッドを追加
- src/main.ts:343の型キャストを削除し、Result型を適切に処理するように修正
- admin/admin.tsからWorkerクラスの直接インポートを削除
- DevcontainerManagerをWorker型からIWorker型を使用するように変更
- 型安全性を向上させ、as unknown as Workerという二重キャストを排除