### PR TITLE
devcontainer.jsonの処理を--configオプション方式に変更

### DIFF
--- a/docs/devcontainer-cli-options.md
+++ b/docs/devcontainer-cli-options.md
@@ -1,0 +1,171 @@
+# devcontainer CLI オプション調査結果
+
+## 概要
+
+devcontainer
+CLIのオプションについて調査した結果、特に`devcontainer up`と`devcontainer exec`コマンドでdevcontainer.jsonファイルを明示的に指定する方法について以下の通り判明しました。
+
+## 1. devcontainer upコマンドでdevcontainer.jsonファイルを明示的に指定する方法
+
+### --configオプション
+
+`devcontainer up`コマンドは`--config`オプションを使用してdevcontainer.jsonファイルのパスを明示的に指定できます。
+
+```bash
+# カスタムパスのdevcontainer.jsonを指定
+devcontainer up --workspace-folder /path/to/project --config ./custom/path/devcontainer.json
+
+# デフォルト以外の場所にあるdevcontainer.jsonを使用
+devcontainer up --config /absolute/path/to/devcontainer.json
+```
+
+**デフォルトパス:**
+
+- `.devcontainer/devcontainer.json`
+- `.devcontainer.json`（プロジェクトルート）
+
+### --override-configオプション
+
+既存のワークスペースのdevcontainer.jsonを上書きする場合に使用します。デフォルトの設定ファイルが存在しない場合は必須となります。
+
+```bash
+devcontainer up --workspace-folder /path/to/project --override-config ./override/devcontainer.json
+```
+
+## 2. --config-fileや類似のオプションについて
+
+調査の結果、`--config-file`という名前のオプションは存在せず、設定ファイルの指定には`--config`オプションを使用することが判明しました。
+
+## 3. devcontainer execコマンドでの指定方法
+
+`devcontainer exec`コマンドでも同様に`--config`オプションが利用可能です。
+
+```bash
+# カスタム設定ファイルを使用してコマンドを実行
+devcontainer exec --workspace-folder /path/to/project --config ./custom/devcontainer.json <command>
+
+# 例：カスタム設定でnpm testを実行
+devcontainer exec --config ./test/devcontainer.json npm test
+```
+
+### execコマンドで利用可能なオプション
+
+- `--config`: devcontainer.jsonパスを指定
+- `--override-config`: ワークスペースのdevcontainer.jsonを上書き
+- `--workspace-folder`:
+  設定を検索するためのパス（configが明示的に指定されていない場合）
+
+## 4. デフォルトパス以外の場所にあるdevcontainer.jsonを使用する方法
+
+### 方法1: --configオプションの使用（推奨）
+
+```bash
+# 絶対パスで指定
+devcontainer up --config /home/user/configs/my-devcontainer.json
+
+# 相対パスで指定
+devcontainer up --workspace-folder . --config ../shared-configs/devcontainer.json
+```
+
+### 方法2: --workspace-folderオプションの活用
+
+`--workspace-folder`で指定したディレクトリ内の標準的な場所（`.devcontainer/devcontainer.json`または`.devcontainer.json`）から設定を読み込みます。
+
+```bash
+# プロジェクトディレクトリを指定
+devcontainer up --workspace-folder /path/to/project
+# → /path/to/project/.devcontainer/devcontainer.json を探す
+```
+
+## 5. その他の重要なオプション
+
+### devcontainer upの主要オプション
+
+- `--workspace-folder`: ワークスペースフォルダのパス
+- `--config`: devcontainer.json設定ファイルのパス
+- `--override-config`: ワークスペースのdevcontainer.jsonを上書き
+- `--docker-compose-path`: Docker Composeファイルのパス
+- `--id-label`: コンテナを識別するためのラベル
+- `--mount`: 追加のマウント指定
+- `--additional-features`: 追加機能の指定
+- `--log-level`: ログレベル（debug、info、warn、error）
+- `--log-format`: ログフォーマット（text、json）
+
+## 6. 実装への推奨事項
+
+現在のコードでは`--workspace-folder`オプションのみを使用していますが、より柔軟な設定ファイルの指定を可能にするために以下の改善を推奨します：
+
+### 現在の実装（src/devcontainer.ts）
+
+```typescript
+function createDevcontainerCommand(
+  repositoryPath: string,
+  env: Record<string, string>,
+): Deno.Command {
+  return new Deno.Command("devcontainer", {
+    args: [
+      "up",
+      "--workspace-folder",
+      repositoryPath,
+      "--log-level",
+      "debug",
+      "--log-format",
+      "json",
+    ],
+    // ...
+  });
+}
+```
+
+### 推奨される改善案
+
+```typescript
+interface DevcontainerCommandOptions {
+  repositoryPath: string;
+  env: Record<string, string>;
+  configPath?: string; // カスタム設定ファイルパス
+}
+
+function createDevcontainerCommand(
+  options: DevcontainerCommandOptions,
+): Deno.Command {
+  const args = [
+    "up",
+    "--workspace-folder",
+    options.repositoryPath,
+    "--log-level",
+    "debug",
+    "--log-format",
+    "json",
+  ];
+
+  // カスタム設定ファイルが指定されている場合
+  if (options.configPath) {
+    args.push("--config", options.configPath);
+  }
+
+  return new Deno.Command("devcontainer", {
+    args,
+    stdout: "piped",
+    stderr: "piped",
+    cwd: options.repositoryPath,
+    env: options.env,
+  });
+}
+```
+
+同様に、`execInDevcontainer`関数でも`--config`オプションをサポートすることで、より柔軟な実行環境の管理が可能になります。
+
+## 7. 注意事項
+
+1. `--config`オプションで指定されたパスは、相対パスの場合は現在の作業ディレクトリからの相対パスとして解釈されます
+2. 設定ファイルが見つからない場合、コマンドはエラーで終了します
+3. `--override-config`は既存の設定を完全に置き換えるため、使用には注意が必要です
+4. devcontainer.jsonは他のdevcontainer.jsonファイルからの設定をインポートまたは継承することはできません
+
+## 参考資料
+
+- [GitHub - devcontainers/cli](https://github.com/devcontainers/cli)
+- [Dev Container CLI - VS Code Documentation](https://code.visualstudio.com/docs/devcontainers/devcontainer-cli)
+- [Dev Container metadata reference](https://containers.dev/implementors/json_reference/)
+- [devcontainer CLI ソースコード (devContainersSpecCLI.ts)](https://github.com/devcontainers/cli/blob/main/src/spec-node/devContainersSpecCLI.ts)

--- a/docs/devcontainer-cli-options.md
+++ b/docs/devcontainer-cli-options.md
@@ -95,7 +95,7 @@ devcontainer up --workspace-folder /path/to/project
 
 現在のコードでは`--workspace-folder`オプションのみを使用していますが、より柔軟な設定ファイルの指定を可能にするために以下の改善を推奨します：
 
-### 現在の実装（src/devcontainer.ts）
+### 現在の実装
 
 ```typescript
 function createDevcontainerCommand(

--- a/src/admin/admin.ts
+++ b/src/admin/admin.ts
@@ -399,7 +399,7 @@ export class Admin implements IAdmin {
       };
     }
 
-    return this.devcontainerManager.startDevcontainerForWorker(
+    return this.devcontainerManager.startDevcontainerWithWorker(
       threadId,
       worker,
       onProgress,
@@ -437,7 +437,7 @@ export class Admin implements IAdmin {
       repository.repo,
     );
 
-    return this.devcontainerManager.startFallbackDevcontainerForWorker(
+    return this.devcontainerManager.startDevcontainerForWorker(
       threadId,
       repositoryPath,
       onProgress,

--- a/src/admin/devcontainer-manager.ts
+++ b/src/admin/devcontainer-manager.ts
@@ -356,9 +356,9 @@ export class DevcontainerManager {
   }
 
   /**
-   * devcontainerの起動を処理する
+   * devcontainerの起動を処理する（Worker経由）
    */
-  async startDevcontainerForWorker(
+  async startDevcontainerWithWorker(
     threadId: string,
     worker: IWorker,
     onProgress?: (message: string) => Promise<void>,
@@ -429,7 +429,7 @@ export class DevcontainerManager {
   /**
    * fallback devcontainerを起動する
    */
-  async startFallbackDevcontainerForWorker(
+  async startDevcontainerForWorker(
     threadId: string,
     repositoryPath: string,
     onProgress?: (message: string) => Promise<void>,

--- a/src/admin/devcontainer-manager.ts
+++ b/src/admin/devcontainer-manager.ts
@@ -1,7 +1,7 @@
 import {
   checkDevcontainerCli,
   checkDevcontainerConfig,
-  startFallbackDevcontainer,
+  startDevcontainer,
 } from "../devcontainer.ts";
 import type { IWorker } from "../worker.ts";
 import type { AuditEntry } from "../workspace.ts";
@@ -454,8 +454,9 @@ export class DevcontainerManager {
       isWorktreePath: worktreePath !== repositoryPath,
     });
 
-    // fallback devcontainerを起動（worktreePathを使用）
-    const result = await startFallbackDevcontainer(
+    // devcontainerを起動（worktreePathを使用）
+    // fallback devcontainer.jsonはgetDevcontainerConfigPathで自動的に選択される
+    const result = await startDevcontainer(
       worktreePath,
       onProgress,
     );

--- a/src/devcontainer_fallback_test.ts
+++ b/src/devcontainer_fallback_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "std/assert/mod.ts";
-import { join } from "std/path/mod.ts";
+import { basename, dirname, fromFileUrl, join } from "std/path/mod.ts";
 import { getDevcontainerConfigPath } from "./devcontainer.ts";
 
 Deno.test("devcontainer設定パス決定機能", async (t) => {
@@ -16,8 +16,13 @@ Deno.test("devcontainer設定パス決定機能", async (t) => {
         assertEquals(result.isOk(), true);
         if (result.isOk()) {
           // fallback devcontainer.jsonのパスが返されることを確認
-          assertEquals(result.value.includes("fallback_devcontainer"), true);
-          assertEquals(result.value.endsWith("devcontainer.json"), true);
+          const filename = basename(result.value);
+          const parentDir = basename(dirname(result.value));
+          const grandParentDir = basename(dirname(dirname(result.value)));
+
+          assertEquals(filename, "devcontainer.json");
+          assertEquals(parentDir, ".devcontainer");
+          assertEquals(grandParentDir, "fallback_devcontainer");
         }
       } finally {
         // クリーンアップ
@@ -65,7 +70,7 @@ Deno.test("devcontainer設定パス決定機能", async (t) => {
 
   await t.step("fallback_devcontainerディレクトリの存在を確認", async () => {
     // fallback_devcontainerディレクトリが存在することを確認
-    const currentDir = new URL(".", import.meta.url).pathname;
+    const currentDir = fromFileUrl(new URL(".", import.meta.url));
     const fallbackDir = join(currentDir, "..", "fallback_devcontainer");
     const fallbackDevcontainerDir = join(fallbackDir, ".devcontainer");
 


### PR DESCRIPTION
## Summary
- devcontainer.jsonファイルの処理を、worktreeへのコピー方式からdevcontainer CLIの--configオプションによる明示的な指定方式に変更しました
- リポジトリ内にdevcontainer.jsonがある場合もない場合も、統一的に処理できるようになりました
- ファイルシステムへの不要な変更を避け、より明確で管理しやすい実装になりました

## 主な変更点
- `getDevcontainerConfigPath`関数を追加し、devcontainer.jsonのパスを解決
- `startDevcontainer`と`execInDevcontainer`関数で`--config`オプションを使用
- `prepareFallbackDevcontainer`関数を削除（worktreeへのコピーが不要に）
- リポジトリ内のdevcontainer.jsonとfallback devcontainerの両方で統一的に処理

## Test plan
[x] deno task test:all:quiet が成功することを確認
[x] 全276テストが成功
[x] devcontainer関連の統合テストが正常に動作
[x] 既存の機能への影響がないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - devcontainer CLIコマンド実行時に、明示的にdevcontainer.jsonのパスを指定できるようになりました。
  - devcontainer.jsonが存在しない場合は、プロジェクト内のフォールバック設定ファイルが自動的に利用されます。

- **ドキュメント**
  - devcontainer CLIオプションやカスタム設定ファイル指定方法に関する詳細なドキュメントを追加しました。

- **リファクタ**
  - フォールバックdevcontainerのコピー・起動処理を削除し、設定ファイルのパス判定ロジックを一本化しました。
  - devcontainer起動関連のメソッド名変更と呼び出し先の整理を行いました。

- **テスト**
  - devcontainer設定ファイルパス判定のテストに内容を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->