### PR TITLE
スレッドの自動アーカイブ期間を1週間に変更

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import {
   Routes,
   SlashCommandBuilder,
   TextChannel,
+  ThreadAutoArchiveDuration,
   ThreadChannel,
 } from "discord.js";
 import { Admin } from "./admin.ts";
@@ -670,7 +671,7 @@ async function handleSlashCommand(interaction: ChatInputCommandInteraction) {
       // スレッドを作成
       const thread = await interaction.channel.threads.create({
         name: `${repository.fullName}-${Date.now()}`,
-        autoArchiveDuration: 60,
+        autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
         reason: `${repository.fullName}のチャットセッション`,
       });
 


### PR DESCRIPTION
## 概要
Discordスレッドが1時間で自動的にアーカイブ（非表示）される設定を1週間に変更しました。

## 変更内容
- Discord.jsから`ThreadAutoArchiveDuration`列挙型をインポート
- スレッド作成時の`autoArchiveDuration`を60（分）から`ThreadAutoArchiveDuration.OneWeek`に変更

## 技術的詳細
- 変更前: `autoArchiveDuration: 60` （1時間）
- 変更後: `autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek` （7日間）

## 注意事項
⚠️ `OneWeek`（7日間）の自動アーカイブ期間を使用するには、Discordサーバーがブーストレベル2以上である必要があります。

もしサーバーのブーストレベルが不足している場合は、以下の代替オプションを検討してください：
- `ThreadAutoArchiveDuration.OneDay`（24時間）
- `ThreadAutoArchiveDuration.ThreeDays`（3日間 - ブーストレベル1以上が必要）

## テスト
- [x] 型チェック: ✅ 成功
- [x] テスト: ✅ 292/292 すべて成功
- [x] Lint: ✅ 成功
- [x] フォーマット: ✅ 成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - スレッドの自動アーカイブ期間が60分から1週間に延長されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->