### PR TITLE
feat: Claude実行失敗時にstdout出力も含めるように改善

### DIFF
--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -340,7 +340,7 @@ export class Worker implements IWorker {
     }
 
     if (code !== 0) {
-      return this.handleErrorMessage(code, stderr);
+      return this.handleErrorMessage(code, stderr, allOutput);
     }
 
     // VERBOSEモードで成功時のstderrも出力（警告等の情報がある場合）
@@ -503,32 +503,61 @@ export class Worker implements IWorker {
   private handleErrorMessage(
     code: number,
     stderr: Uint8Array,
+    stdout: string,
   ): Result<never, WorkerError> {
-    const errorMessage = new TextDecoder().decode(stderr);
+    const stderrMessage = new TextDecoder().decode(stderr);
 
-    // VERBOSEモードでstderrを詳細ログ出力
-    if (this.configuration.isVerbose() && stderr.length > 0) {
-      console.log(
-        `[${
-          new Date().toISOString()
-        }] [Worker:${this.state.workerName}] Claude stderr:`,
-      );
-      console.log(`  終了コード: ${code}`);
-      console.log(`  エラー内容:`);
-      console.log(
-        `    ${
-          errorMessage.split("\n").map((line) => `    ${line}`).join("\n")
-        }`,
-      );
+    // VERBOSEモードで詳細ログ出力
+    if (this.configuration.isVerbose()) {
+      // stdout出力（エラー時）
+      if (stdout.trim()) {
+        console.log(
+          `[${
+            new Date().toISOString()
+          }] [Worker:${this.state.workerName}] Claude stdout (エラー時):`,
+        );
+        console.log(
+          `  ${stdout.split("\n").map((line) => `  ${line}`).join("\n")}`,
+        );
+      }
+
+      // stderr出力
+      if (stderr.length > 0) {
+        console.log(
+          `[${
+            new Date().toISOString()
+          }] [Worker:${this.state.workerName}] Claude stderr:`,
+        );
+        console.log(`  終了コード: ${code}`);
+        console.log(`  エラー内容:`);
+        console.log(
+          `    ${
+            stderrMessage.split("\n").map((line) => `    ${line}`).join("\n")
+          }`,
+        );
+      }
+    }
+
+    // エラーメッセージの構築（stdoutも含める）
+    let errorDetail = `Claude実行失敗 (終了コード: ${code})`;
+    if (stderrMessage.trim()) {
+      errorDetail += `\nstderr: ${stderrMessage}`;
+    }
+    if (stdout.trim()) {
+      // stdoutの最後の10行を含める（長すぎる場合は切り詰め）
+      const stdoutLines = stdout.trim().split("\n");
+      const lastLines = stdoutLines.slice(-10).join("\n");
+      errorDetail += `\nstdout (最後の10行): ${lastLines}`;
     }
 
     this.logVerbose("ストリーミング実行エラー", {
       exitCode: code,
-      errorMessage,
+      stderrMessage,
+      stdoutLength: stdout.length,
     });
     return err({
       type: "CLAUDE_EXECUTION_FAILED",
-      error: `Claude実行失敗 (終了コード: ${code}): ${errorMessage}`,
+      error: errorDetail,
     });
   }
 


### PR DESCRIPTION
## Summary
- Claude実行失敗時のエラーログにstdout出力も含めるように改善
- デバッグ時の情報量を増やし、問題の原因特定を容易に

## Changes
- `handleErrorMessage`メソッドにstdout引数を追加
- VERBOSEモードでstdoutとstderrの両方を詳細出力
- エラーメッセージにstdoutの最後の10行を含める

## Test plan
[x] 既存のテストが全て通ることを確認
[x] 型チェック、lint、フォーマットの検証に成功

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - エラー発生時のメッセージに標準出力（stdout）の内容も含めて、より詳細なエラー内容が表示されるようになりました。
  - エラー時のログに標準出力と標準エラー出力（stderr）の両方が記録されるよう改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->